### PR TITLE
Add BIP324 transport support and session_id for identity binding

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,6 +39,7 @@ rustls = { version = "0.23.40", default-features = false, features = ["std", "ri
 nostr = "0.44.2"
 crossbeam-channel = "0.5.15"
 hotpath = "0.15.0"
+bip324 = "0.10.0"
 
 [dev-dependencies]
 flate2 = {version = "1.0.35"}

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,7 +39,8 @@ rustls = { version = "0.23.40", default-features = false, features = ["std", "ri
 nostr = "0.44.2"
 crossbeam-channel = "0.5.15"
 hotpath = "0.15.0"
-bip324 = "0.10.0"
+bip324 = { git = "https://github.com/YoganshSharma/bip324", rev = "bcccdecbf424af5d679723efbf0c02556cc05c25" }
+# bip324 = "0.10.0"
 
 [dev-dependencies]
 flate2 = {version = "1.0.35"}

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,6 +40,7 @@ tungstenite = { version = "0.28.0", features = ["rustls-tls-webpki-roots"]}
 rustls = { version = "0.23.40", default-features = false, features = ["std", "ring"] }
 nostr = "0.44.2"
 crossbeam-channel = "0.5.15"
+bip324 = { git = "https://github.com/rust-bitcoin/bip324", rev = "7c8894452929e1f1019e27a84ef8d6834facaa47" } # TODO move to v0.12.0 when it releases
 
 [dev-dependencies]
 flate2 = {version = "1.0.35"}

--- a/src/bip324_stream.rs
+++ b/src/bip324_stream.rs
@@ -1,0 +1,145 @@
+//! BIP324 transport layer for OpenSwap's peer-to-peer communication.
+//!
+//! This module wraps the [`bip324`] crate's `Protocol` into a
+//! `Bip324Stream` that CBOR-(de)serializes the application's messages on top
+//! of the encrypted BIP324 transport.
+//!
+//! Both the Taker (as BIP324 *initiator*) and the Maker (as BIP324 *responder*)
+//! speak through this module.
+
+use std::{io::BufReader, net::TcpStream};
+
+use bip324::io::{Payload, Protocol};
+use bitcoin::{
+    secp256k1::{ecdsa::Signature, Message, Secp256k1},
+    Network, PublicKey,
+};
+use serde::{de::DeserializeOwned, Serialize};
+
+use crate::error::NetError;
+
+/// Errors specific to the BIP324 transport and its authentication handshake.
+#[derive(Debug)]
+pub enum Bip324Error {
+    /// The peer aborted the BIP324 protocol (e.g. unexpected packet or stream error).
+    ProtocolError(bip324::io::ProtocolError),
+    /// The peer's session ID did not match ours, indicating a man-in-the-middle attack.
+    SessionIdMismatch,
+    /// The maker's `session_id_sig` did not verify against its tweakable key.
+    SessionIdSigInvalid(bitcoin::secp256k1::Error),
+    /// The peer cleanly disconnected (EOF / connection closed).
+    ConnectionClosed,
+}
+
+impl From<bip324::io::ProtocolError> for Bip324Error {
+    fn from(value: bip324::io::ProtocolError) -> Self {
+        match value {
+            // `RetryV1` is the BIP324 crate's way of reporting that the remote
+            // closed the stream cleanly, so map it to a dedicated variant.
+            bip324::io::ProtocolError::Io(_, bip324::io::ProtocolFailureSuggestion::RetryV1) => {
+                Self::ConnectionClosed
+            }
+            _ => Self::ProtocolError(value),
+        }
+    }
+}
+
+/// Role of the local peer on a `Bip324Stream`.
+#[derive(Debug)]
+pub(crate) enum OpenswapRole {
+    /// We are the maker (BIP324 responder); no authentication is needed.
+    Maker,
+    /// We are the taker (BIP324 initiator).
+    Taker {
+        /// Whether the maker's `session_id_sig` was verified against its
+        /// tweakable key (see `Bip324Stream::authenticate`).
+        is_authenticated: bool,
+    },
+}
+
+/// An encrypted, authenticated transport channel to a peer.
+///
+/// Wraps the BIP324 `Protocol` over a `TcpStream` and adds CBOR (de)serialization on top of genuine payloads.
+pub(crate) struct Bip324Stream {
+    /// The underlying BIP324 protocol stream.
+    pub stream: Protocol<BufReader<TcpStream>, TcpStream>,
+    /// Local role on this connection (maker vs taker).
+    pub role: OpenswapRole,
+}
+
+impl std::fmt::Debug for Bip324Stream {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("Bip324Stream").finish_non_exhaustive()
+    }
+}
+
+impl Bip324Stream {
+    /// Wrap a connected TCP stream in a fresh BIP324 transport.
+    pub fn new(
+        stream: TcpStream,
+        network: Network,
+        bip324_role: bip324::Role,
+    ) -> Result<Self, NetError> {
+        let reader = BufReader::new(stream.try_clone()?);
+        let writer = stream;
+        let stream = Protocol::new(
+            network.magic(),
+            bip324_role,
+            None,
+            None, // no garbage or decoys
+            reader,
+            writer,
+        )?;
+
+        Ok(Self {
+            stream,
+            role: match bip324_role {
+                bip324::Role::Initiator => OpenswapRole::Taker {
+                    is_authenticated: false,
+                },
+                bip324::Role::Responder => OpenswapRole::Maker,
+            },
+        })
+    }
+
+    /// Read the next genuine application message, deserializing it as `T`.
+    pub(crate) fn read_message<T: DeserializeOwned>(&mut self) -> Result<T, NetError> {
+        loop {
+            let payload = self.stream.read()?;
+            match payload.packet_type() {
+                // Currently we never send decoys, but tolerate them defensively.
+                bip324::PacketType::Decoy => {}
+                bip324::PacketType::Genuine => {
+                    return Ok(serde_cbor::from_slice(payload.contents())?);
+                }
+            }
+        }
+    }
+
+    /// Serialize a message to CBOR and send it as a genuine BIP324 payload.
+    pub(crate) fn send_message(&mut self, message: &impl Serialize) -> Result<(), NetError> {
+        let msg_bytes = serde_cbor::ser::to_vec(message)?;
+        let to_send = Payload::genuine(msg_bytes);
+
+        self.stream.write(&to_send)?;
+
+        Ok(())
+    }
+
+    /// Bind the BIP324 session to the maker's identity and mark the channel authenticated.
+    pub(crate) fn authenticate(
+        &mut self,
+        tweakable_point: &PublicKey,
+        session_id_sig: &Signature,
+    ) -> Result<(), NetError> {
+        let session_id = *self.stream.session_id().as_bytes();
+        let secp = Secp256k1::new();
+        let sighash = Message::from_digest(session_id);
+        secp.verify_ecdsa(&sighash, session_id_sig, &tweakable_point.inner)
+            .map_err(|e| NetError::Bip324Error(Bip324Error::SessionIdSigInvalid(e)))?;
+        if let OpenswapRole::Taker { is_authenticated } = &mut self.role {
+            *is_authenticated = true;
+        }
+        Ok(())
+    }
+}

--- a/src/error.rs
+++ b/src/error.rs
@@ -26,6 +26,24 @@ pub enum NetError {
 
     /// Error indicating an invalid CLI application network.
     InvalidAppNetwork,
+
+    /// Error related to Bip324
+    Bip324Error(Bip324Error),
+}
+
+/// Represents errors specific to the BIP324 protocol.
+#[derive(Debug)]
+pub enum Bip324Error {
+    /// Error indicating that an unexpected decoy was encountered during the BIP324 protocol execution.
+    UnexpectedDecoy,
+    /// Error indicating that the protocol was aborted by the peer.
+    ProtocolError(bip324::io::ProtocolError),
+}
+
+impl From<bip324::io::ProtocolError> for Bip324Error {
+    fn from(value: bip324::io::ProtocolError) -> Self {
+        Self::ProtocolError(value)
+    }
 }
 
 impl std::fmt::Display for NetError {
@@ -49,6 +67,18 @@ impl From<std::io::Error> for NetError {
 impl From<serde_cbor::Error> for NetError {
     fn from(value: serde_cbor::Error) -> Self {
         Self::Cbor(value)
+    }
+}
+
+impl From<bip324::io::ProtocolError> for NetError {
+    fn from(value: bip324::io::ProtocolError) -> Self {
+        Self::Bip324Error(Bip324Error::ProtocolError(value))
+    }
+}
+
+impl From<Bip324Error> for NetError {
+    fn from(value: Bip324Error) -> Self {
+        Self::Bip324Error(value)
     }
 }
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -38,6 +38,10 @@ pub enum Bip324Error {
     UnexpectedDecoy,
     /// Error indicating that the protocol was aborted by the peer.
     ProtocolError(bip324::io::ProtocolError),
+    /// Error due to mismatch in session IDs indicates MitM attack
+    SessionIdMismatch,
+    /// Error when session_id signature does not match
+    SessionIdSigInvalid(bitcoin::secp256k1::Error),
 }
 
 impl From<bip324::io::ProtocolError> for Bip324Error {

--- a/src/error.rs
+++ b/src/error.rs
@@ -2,6 +2,8 @@
 
 use std::error::Error;
 
+use crate::bip324_stream::Bip324Error;
+
 /// Represents all possible network-related errors.
 #[derive(Debug)]
 pub enum NetError {
@@ -29,6 +31,9 @@ pub enum NetError {
 
     /// Error indicating an invalid CLI application network.
     InvalidAppNetwork,
+
+    /// Error related to Bip324
+    Bip324Error(Bip324Error),
 }
 
 impl std::fmt::Display for NetError {
@@ -52,6 +57,18 @@ impl From<std::io::Error> for NetError {
 impl From<serde_cbor::Error> for NetError {
     fn from(value: serde_cbor::Error) -> Self {
         Self::Cbor(value)
+    }
+}
+
+impl From<bip324::io::ProtocolError> for NetError {
+    fn from(value: bip324::io::ProtocolError) -> Self {
+        Self::Bip324Error(value.into())
+    }
+}
+
+impl From<Bip324Error> for NetError {
+    fn from(value: Bip324Error) -> Self {
+        Self::Bip324Error(value)
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,6 +3,7 @@
 pub extern crate bitcoin;
 pub extern crate bitcoind;
 
+pub mod bip324_stream;
 pub mod error;
 pub mod fee_estimation;
 pub mod maker;

--- a/src/maker/error.rs
+++ b/src/maker/error.rs
@@ -5,7 +5,10 @@ use std::sync::{MutexGuard, PoisonError, RwLockReadGuard, RwLockWriteGuard};
 use bitcoin::{secp256k1, Amount};
 
 use crate::{
-    error::NetError, protocol::error::ProtocolError, utill::TorError, wallet::WalletError,
+    error::{Bip324Error, NetError},
+    protocol::error::ProtocolError,
+    utill::TorError,
+    wallet::WalletError,
     watch_tower::watcher_error::WatcherError,
 };
 
@@ -128,5 +131,17 @@ impl From<NetError> for MakerError {
 impl From<WatcherError> for MakerError {
     fn from(value: WatcherError) -> Self {
         Self::Watcher(value)
+    }
+}
+
+impl From<bip324::io::ProtocolError> for MakerError {
+    fn from(value: bip324::io::ProtocolError) -> Self {
+        Self::Net(value.into())
+    }
+}
+
+impl From<Bip324Error> for MakerError {
+    fn from(value: Bip324Error) -> Self {
+        Self::Net(value.into())
     }
 }

--- a/src/maker/error.rs
+++ b/src/maker/error.rs
@@ -5,8 +5,8 @@ use std::sync::{MutexGuard, PoisonError, RwLockReadGuard, RwLockWriteGuard};
 use bitcoin::{secp256k1, Amount};
 
 use crate::{
-    error::NetError, protocol::error::ProtocolError, utill::TorError, wallet::WalletError,
-    watch_tower::watcher_error::WatcherError,
+    bip324_stream::Bip324Error, error::NetError, protocol::error::ProtocolError, utill::TorError,
+    wallet::WalletError, watch_tower::watcher_error::WatcherError,
 };
 
 #[cfg(feature = "integration-test")]
@@ -132,5 +132,17 @@ impl From<NetError> for MakerError {
 impl From<WatcherError> for MakerError {
     fn from(value: WatcherError) -> Self {
         Self::Watcher(value)
+    }
+}
+
+impl From<bip324::io::ProtocolError> for MakerError {
+    fn from(value: bip324::io::ProtocolError) -> Self {
+        Self::Net(value.into())
+    }
+}
+
+impl From<Bip324Error> for MakerError {
+    fn from(value: Bip324Error) -> Self {
+        Self::Net(value.into())
     }
 }

--- a/src/maker/handlers.rs
+++ b/src/maker/handlers.rs
@@ -8,7 +8,7 @@ use super::error::MakerError;
 use crate::{
     protocol::{
         common_messages::{
-            AckSwapDetails, FidelityProof, GetOffer, MakerHello, MakerToTakerMessage, Offer,
+            AckSwap, FidelityProof, GetOffer, MakerHello, MakerToTakerMessage, Offer,
             ProtocolVersion, SwapDetails, TakerHello, TakerToMakerMessage,
         },
         legacy_messages::LegacyTakerMessage,
@@ -59,6 +59,8 @@ pub const MIN_CONTRACT_REACTION_TIME: u16 = 10;
 pub struct ConnectionState {
     /// Protocol version being used for this connection.
     pub protocol: ProtocolVersion,
+    /// Unique identifier for the connection, None indicates no connection yet
+    pub session_id: Option<[u8; 32]>,
     /// Current phase of the swap.
     pub phase: SwapPhase,
     /// Unique swap identifier.
@@ -110,6 +112,7 @@ impl Default for ConnectionState {
     fn default() -> Self {
         ConnectionState {
             protocol: ProtocolVersion::Legacy,
+            session_id: None,
             phase: SwapPhase::AwaitingHello,
             swap_id: None,
             swap_amount: Amount::ZERO,
@@ -402,7 +405,6 @@ fn handle_taker_hello<M: Maker>(
         Maker::network_port(maker.as_ref()),
         config.supported_protocols
     );
-
     Ok(Some(MakerToTakerMessage::MakerHello(MakerHello {
         supported_protocols: config.supported_protocols,
     })))
@@ -478,7 +480,14 @@ fn handle_swap_details<M: Maker>(
 
     maker.store_connection_state(&details.id, state)?;
 
-    let (_, tweakable_point) = maker.get_tweakable_keypair()?;
+    let (tweakable_privkey, tweakable_point) = maker.get_tweakable_keypair()?;
+
+    let session_id = state.session_id.unwrap();
+    let secp = bitcoin::secp256k1::Secp256k1::new();
+    let session_id_sig = secp.sign_ecdsa_low_r(
+        &bitcoin::secp256k1::Message::from_digest(session_id),
+        &tweakable_privkey,
+    );
 
     log::info!(
         "[{}] Accepting swap (id: {})",
@@ -495,9 +504,11 @@ fn handle_swap_details<M: Maker>(
         return Err(MakerError::General("Test: closing after ack response"));
     }
 
-    Ok(Some(MakerToTakerMessage::AckSwapDetails(
-        AckSwapDetails::accept(tweakable_point),
-    )))
+    Ok(Some(MakerToTakerMessage::AckSwap(AckSwap::accept(
+        tweakable_point,
+        session_id,
+        session_id_sig,
+    ))))
 }
 
 /// Restore connection state if this is a new/reconnected connection.

--- a/src/maker/handlers.rs
+++ b/src/maker/handlers.rs
@@ -2,6 +2,7 @@
 
 use std::{sync::Arc, time::Instant};
 
+use bip324::SessionId;
 use bitcoin::{bip32::ChainCode, Amount, PublicKey, Transaction};
 
 use super::error::MakerError;
@@ -116,6 +117,8 @@ pub(crate) fn past_refund_deadline(
 pub struct ConnectionState {
     /// Protocol version being used for this connection.
     pub protocol: ProtocolVersion,
+    /// Unique identifier for the connection, None indicates no connection yet
+    pub session_id: Option<SessionId>,
     /// Current phase of the swap.
     pub phase: SwapPhase,
     /// Unique swap identifier.
@@ -171,6 +174,7 @@ impl Default for ConnectionState {
     fn default() -> Self {
         ConnectionState {
             protocol: ProtocolVersion::Legacy,
+            session_id: None,
             phase: SwapPhase::AwaitingHello,
             swap_id: None,
             swap_amount: Amount::ZERO,
@@ -516,14 +520,26 @@ fn handle_taker_hello<M: Maker>(
     let config = maker.get_config();
     state.phase = SwapPhase::AwaitingOfferRequest;
 
+    let session_id = state
+        .session_id
+        .ok_or(MakerError::General("Connection did not start"))?;
+    // Sign the BIP324 session ID with our tweakable key so the taker can bind
+    // this encrypted channel to our identity (proving we own the advertised tweakable point)
+    let (tweakable_privkey, _, _) = maker.get_tweakable_keypair()?;
+    let secp = bitcoin::secp256k1::Secp256k1::new();
+    let session_id_sig = secp.sign_ecdsa_low_r(
+        &bitcoin::secp256k1::Message::from_digest(session_id.to_bytes()),
+        &tweakable_privkey,
+    );
+
     log::info!(
         "[{}] Supported protocols: {:?}",
         Maker::network_port(maker.as_ref()),
         config.supported_protocols
     );
-
     Ok(Some(MakerToTakerMessage::MakerHello(MakerHello {
         supported_protocols: config.supported_protocols,
+        session_id_sig,
     })))
 }
 

--- a/src/maker/server.rs
+++ b/src/maker/server.rs
@@ -27,11 +27,11 @@ struct MakerBip324Wrapper {
 }
 
 impl MakerBip324Wrapper {
-    fn new(stream: TcpStream, network: bip324::Network) -> Result<Self, ProtocolError> {
+    fn new(stream: TcpStream, network: bitcoin::Network) -> Result<Self, ProtocolError> {
         let reader = stream.try_clone()?;
         let writer = stream;
         let protocol = bip324::io::Protocol::new(
-            network,
+            network.magic(),
             bip324::Role::Responder,
             None,
             None,

--- a/src/maker/server.rs
+++ b/src/maker/server.rs
@@ -12,12 +12,62 @@ use std::{
 };
 
 use crate::{
+    error::Bip324Error,
     maker::rpc::server::MakerRpc,
     nostr_coinswap::broadcast_bond_on_nostr,
     protocol::common_messages::{FidelityProof, MakerToTakerMessage, TakerToMakerMessage},
     utill::HEART_BEAT_INTERVAL,
     wallet::RecoveryReport,
 };
+
+use bip324::io::{Payload, ProtocolError};
+
+struct MakerBip324Wrapper {
+    protocol: bip324::io::Protocol<TcpStream, TcpStream>,
+}
+
+impl MakerBip324Wrapper {
+    fn new(stream: TcpStream, network: bip324::Network) -> Result<Self, ProtocolError> {
+        let reader = stream.try_clone()?;
+        let writer = stream;
+        let protocol = bip324::io::Protocol::new(
+            network,
+            bip324::Role::Responder,
+            None,
+            None,
+            reader,
+            writer,
+        )?;
+        Ok(Self { protocol })
+    }
+
+    #[hotpath::measure]
+    fn read_message(&mut self) -> Result<TakerToMakerMessage, MakerError> {
+        let payload = self.protocol.read()?;
+        let contents = payload.contents();
+        match payload.packet_type() {
+            bip324::PacketType::Decoy => {
+                // TODO implement proper decoy handling
+                log::info!("Received decoy message");
+                Err(Bip324Error::UnexpectedDecoy.into())
+            }
+            bip324::PacketType::Genuine => {
+                let message: TakerToMakerMessage = serde_cbor::from_slice(contents)
+                    .map_err(|_| MakerError::General("Failed to deserialize"))?;
+                Ok(message)
+            }
+        }
+    }
+
+    #[hotpath::measure]
+    fn send_message(&mut self, message: &MakerToTakerMessage) -> Result<(), MakerError> {
+        let buf = serde_cbor::to_vec(message)
+            .map_err(|_| MakerError::General("Failed to serialize message"))?;
+        let payload = Payload::genuine(buf);
+        self.protocol.write(&payload)?;
+        Ok(())
+    }
+}
 
 use super::{
     api::MakerServer,
@@ -284,7 +334,7 @@ fn handle_connection(maker: Arc<MakerServer>, stream: TcpStream) -> Result<(), M
         "[{}] Starting connection handler",
         maker.config.network_port
     );
-
+    let mut wrapper = MakerBip324Wrapper::new(stream, maker.config.network)?;
     loop {
         // Check for shutdown
         if maker.is_shutdown() {
@@ -300,7 +350,7 @@ fn handle_connection(maker: Arc<MakerServer>, stream: TcpStream) -> Result<(), M
             break;
         }
 
-        let message = match read_message(&stream) {
+        let message = match wrapper.read_message() {
             Ok(msg) => msg,
             Err(e) => {
                 log::debug!(
@@ -334,7 +384,7 @@ fn handle_connection(maker: Arc<MakerServer>, stream: TcpStream) -> Result<(), M
                 response
             );
 
-            if let Err(e) = send_message(&stream, &response) {
+            if let Err(e) = wrapper.send_message(&response) {
                 log::error!(
                     "[{}] Failed to send response: {:?}",
                     maker.config.network_port,
@@ -953,52 +1003,6 @@ fn recover_from_swap(
 
         sleep(HEART_BEAT_INTERVAL);
     }
-
-    Ok(())
-}
-
-/// Read a message from a stream.
-#[hotpath::measure]
-fn read_message(stream: &TcpStream) -> Result<TakerToMakerMessage, MakerError> {
-    let mut len_buf = [0u8; 4];
-    use std::io::Read;
-
-    let mut stream_ref = stream;
-    stream_ref
-        .read_exact(&mut len_buf)
-        .map_err(MakerError::IO)?;
-
-    let len = u32::from_be_bytes(len_buf) as usize;
-
-    if len > 10 * 1024 * 1024 {
-        return Err(MakerError::General("Message too large"));
-    }
-
-    let mut buf = vec![0u8; len];
-    stream_ref.read_exact(&mut buf).map_err(MakerError::IO)?;
-
-    let message: TakerToMakerMessage = serde_cbor::from_slice(&buf)
-        .map_err(|_| MakerError::General("Failed to deserialize message"))?;
-
-    Ok(message)
-}
-
-/// Send a message to a stream.
-#[hotpath::measure]
-fn send_message(stream: &TcpStream, message: &MakerToTakerMessage) -> Result<(), MakerError> {
-    let buf = serde_cbor::to_vec(message)
-        .map_err(|_| MakerError::General("Failed to serialize message"))?;
-
-    let len = buf.len() as u32;
-    use std::io::Write;
-
-    let mut stream_ref = stream;
-    stream_ref
-        .write_all(&len.to_be_bytes())
-        .map_err(MakerError::IO)?;
-
-    stream_ref.write_all(&buf).map_err(MakerError::IO)?;
-    stream_ref.flush().map_err(MakerError::IO)?;
 
     Ok(())
 }

--- a/src/maker/server.rs
+++ b/src/maker/server.rs
@@ -20,18 +20,19 @@ use crate::{
     wallet::RecoveryReport,
 };
 
-use bip324::io::{Payload, ProtocolError};
+use bip324::io::Payload;
 
 struct MakerBip324Wrapper {
     protocol: bip324::io::Protocol<TcpStream, TcpStream>,
 }
 
 impl MakerBip324Wrapper {
-    fn new(stream: TcpStream, network: bitcoin::Network) -> Result<Self, ProtocolError> {
+    fn new(stream: TcpStream, maker: Arc<MakerServer>) -> Result<Self, MakerError> {
         let reader = stream.try_clone()?;
         let writer = stream;
+        let network_magic = maker.config.network.magic();
         let protocol = bip324::io::Protocol::new(
-            network.magic(),
+            network_magic,
             bip324::Role::Responder,
             None,
             None,
@@ -334,7 +335,8 @@ fn handle_connection(maker: Arc<MakerServer>, stream: TcpStream) -> Result<(), M
         "[{}] Starting connection handler",
         maker.config.network_port
     );
-    let mut wrapper = MakerBip324Wrapper::new(stream, maker.config.network)?;
+    let mut wrapper = MakerBip324Wrapper::new(stream, Arc::clone(&maker))?;
+    state.session_id = Some(*wrapper.protocol.session_id());
     loop {
         // Check for shutdown
         if maker.is_shutdown() {

--- a/src/maker/server.rs
+++ b/src/maker/server.rs
@@ -14,10 +14,12 @@ use std::{
 #[cfg(not(feature = "integration-test"))]
 use crate::maker::rpc::server::MakerRpc;
 use crate::{
+    bip324_stream::{Bip324Error, Bip324Stream},
+    error::NetError,
     lock_debug,
     maker::nostr::broadcast_bond_on_nostr,
-    protocol::common_messages::{MakerToTakerMessage, TakerToMakerMessage},
-    utill::{HEART_BEAT_INTERVAL, MAX_RPC_MESSAGE_SIZE},
+    protocol::common_messages::TakerToMakerMessage,
+    utill::HEART_BEAT_INTERVAL,
     wallet::{Blockchain, RecoveryReport, Wallet},
 };
 
@@ -370,7 +372,12 @@ fn handle_connection(maker: Arc<MakerServer>, stream: Arc<TcpStream>) -> Result<
         "[{}] Starting connection handler",
         maker.config.network_port
     );
-
+    let mut encrypted_stream = Bip324Stream::new(
+        stream.as_ref().try_clone()?,
+        maker.network(),
+        bip324::Role::Responder,
+    )?;
+    state.session_id = Some(*encrypted_stream.stream.session_id());
     loop {
         // Check for shutdown
         if maker.is_shutdown() {
@@ -381,13 +388,17 @@ fn handle_connection(maker: Arc<MakerServer>, stream: Arc<TcpStream>) -> Result<
             break;
         }
 
-        if state.is_timed_out(IDLE_CONNECTION_TIMEOUT.as_secs()) {
+        if state.is_timed_out(IDLE_CONNECTION_TIMEOUT.as_secs()) && swap_is_quiet(&maker, &state) {
             log::info!("[{}] Connection timed out", maker.config.network_port);
             break;
         }
 
-        let message = match read_message(&stream) {
+        let message: TakerToMakerMessage = match encrypted_stream.read_message() {
             Ok(msg) => msg,
+            Err(NetError::Bip324Error(Bip324Error::ConnectionClosed)) => {
+                log::info!("[{}] Client disconnected", maker.config.network_port);
+                break;
+            }
             Err(e) => {
                 // A read timeout is only a wakeup: keepalives arrive on separate
                 // connections and refresh the shared swap activity. Break only
@@ -395,12 +406,7 @@ fn handle_connection(maker: Arc<MakerServer>, stream: Arc<TcpStream>) -> Result<
                 if is_read_timeout(&e) && !swap_is_quiet(&maker, &state) {
                     continue;
                 }
-                log::debug!(
-                    "[{}] Read error (may be normal disconnect): {:?}",
-                    maker.config.network_port,
-                    e
-                );
-                break;
+                return Err(e.into());
             }
         };
 
@@ -431,7 +437,7 @@ fn handle_connection(maker: Arc<MakerServer>, stream: Arc<TcpStream>) -> Result<
                 response
             );
 
-            if let Err(e) = send_message(&stream, &response) {
+            if let Err(e) = encrypted_stream.send_message(&response) {
                 log::error!(
                     "[{}] Failed to send response: {:?}",
                     maker.config.network_port,
@@ -509,8 +515,14 @@ fn handle_connection(maker: Arc<MakerServer>, stream: Arc<TcpStream>) -> Result<
 }
 
 /// True when the error is the socket read timeout firing, not a real IO failure.
-fn is_read_timeout(e: &MakerError) -> bool {
-    matches!(e, MakerError::IO(io) if io.kind() == ErrorKind::WouldBlock)
+fn is_read_timeout(e: &NetError) -> bool {
+    match e {
+        NetError::IO(io) => io.kind() == ErrorKind::WouldBlock,
+        NetError::Bip324Error(Bip324Error::ProtocolError(bip324::io::ProtocolError::Io(io, _))) => {
+            io.kind() == ErrorKind::WouldBlock
+        }
+        _ => false,
+    }
 }
 
 /// A swap is quiet when neither this connection nor any keepalive connection
@@ -1146,50 +1158,6 @@ fn recover_from_swap(
 
         sleep(HEART_BEAT_INTERVAL);
     }
-
-    Ok(())
-}
-
-/// Read a message from a stream.
-fn read_message(stream: &TcpStream) -> Result<TakerToMakerMessage, MakerError> {
-    let mut len_buf = [0u8; 4];
-    use std::io::Read;
-
-    let mut stream_ref = stream;
-    stream_ref
-        .read_exact(&mut len_buf)
-        .map_err(MakerError::IO)?;
-
-    let len = u32::from_be_bytes(len_buf) as usize;
-
-    if len > MAX_RPC_MESSAGE_SIZE {
-        return Err(MakerError::General("Message too large"));
-    }
-
-    let mut buf = vec![0u8; len];
-    stream_ref.read_exact(&mut buf).map_err(MakerError::IO)?;
-
-    let message: TakerToMakerMessage = serde_cbor::from_slice(&buf)
-        .map_err(|_| MakerError::General("Failed to deserialize message"))?;
-
-    Ok(message)
-}
-
-/// Send a message to a stream.
-fn send_message(stream: &TcpStream, message: &MakerToTakerMessage) -> Result<(), MakerError> {
-    let buf = serde_cbor::to_vec(message)
-        .map_err(|_| MakerError::General("Failed to serialize message"))?;
-
-    let len = buf.len() as u32;
-    use std::io::Write;
-
-    let mut stream_ref = stream;
-    stream_ref
-        .write_all(&len.to_be_bytes())
-        .map_err(MakerError::IO)?;
-
-    stream_ref.write_all(&buf).map_err(MakerError::IO)?;
-    stream_ref.flush().map_err(MakerError::IO)?;
 
     Ok(())
 }

--- a/src/protocol/common_messages.rs
+++ b/src/protocol/common_messages.rs
@@ -101,20 +101,37 @@ pub struct SwapDetails {
 
 /// Acknowledgment of swap details from Maker.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
-pub struct AckSwapDetails {
-    /// Whether the swap is accepted.
-    /// If Some, contains the tweakable point for this swap.
-    /// If None, swap is rejected.
-    pub tweakable_point: Option<PublicKey>,
+pub enum AckSwap {
+    /// Maker accepted the swap and provides the tweakable point, session ID, and session ID signature.
+    Acknowledged(AckSwapDetails),
+    /// Maker rejected the swap.
+    Rejected,
 }
 
-impl AckSwapDetails {
+/// Acknowledgment of swap details from Maker.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct AckSwapDetails {
+    /// contains the tweakable
+    pub tweakable_point: PublicKey,
+    /// Unique session ID for this connection (32 bytes).
+    pub session_id: [u8; 32],
+    /// ECDSA signature over session_id using the maker's identity key, proving ownership and binding to maker address.
+    pub session_id_sig: bitcoin::secp256k1::ecdsa::Signature,
+}
+
+impl AckSwap {
     /// Create an acceptance response.
     #[hotpath::measure]
-    pub fn accept(tweakable_point: PublicKey) -> Self {
-        AckSwapDetails {
-            tweakable_point: Some(tweakable_point),
-        }
+    pub fn accept(
+        tweakable_point: PublicKey,
+        session_id: [u8; 32],
+        session_id_sig: bitcoin::secp256k1::ecdsa::Signature,
+    ) -> Self {
+        AckSwap::Acknowledged(AckSwapDetails {
+            tweakable_point,
+            session_id,
+            session_id_sig,
+        })
     }
 }
 
@@ -171,7 +188,7 @@ pub enum MakerToTakerMessage {
     /// Maker's offer (fees, limits, fidelity bond).
     Offer(Box<Offer>),
     /// Acknowledgment of swap parameters.
-    AckSwapDetails(AckSwapDetails),
+    AckSwap(AckSwap),
     /// Response with signatures for sender's contract.
     RespContractSigsForSender(RespContractSigsForSender),
     /// Request signatures for both receiver and sender contracts.

--- a/src/protocol/common_messages.rs
+++ b/src/protocol/common_messages.rs
@@ -49,6 +49,8 @@ pub struct TakerHello;
 pub struct MakerHello {
     /// Protocol versions this maker supports.
     pub supported_protocols: Vec<ProtocolVersion>,
+    /// ECDSA signature over session_id using the maker's identity key, proving ownership and binding to maker address.
+    pub session_id_sig: bitcoin::secp256k1::ecdsa::Signature,
 }
 
 /// Request for offer from Taker to Maker.

--- a/src/taker/api.rs
+++ b/src/taker/api.rs
@@ -17,6 +17,7 @@ use super::swap_tracker::{
     SwapTracker, TaprootExchangeProgress,
 };
 
+use bip324::io::{Payload, ProtocolError};
 use bitcoin::{
     hashes::{hash160::Hash as Hash160, Hash},
     hex::DisplayHex,
@@ -26,10 +27,11 @@ use bitcoin::{
     },
     Amount, OutPoint, PublicKey,
 };
-use bitcoind::bitcoincore_rpc::{json::ListUnspentResultEntry, RpcApi};
+use bitcoind::bitcoincore_rpc::{json::ListUnspentResultEntry, Client, RpcApi};
 use socks::Socks5Stream;
 
 use crate::{
+    error::{Bip324Error, NetError},
     nostr_coinswap::NOSTR_RELAYS,
     protocol::{
         common_messages::{
@@ -38,7 +40,7 @@ use crate::{
         },
         contract::calculate_pubkey_from_nonce,
     },
-    utill::{check_tor_status, generate_maker_keys, get_taker_dir, read_message, send_message},
+    utill::{check_tor_status, generate_maker_keys, get_taker_dir},
     wallet::{
         swapcoin::{IncomingSwapCoin, OutgoingSwapCoin, WatchOnlySwapCoin},
         MakerFeeInfo as ReportMakerFeeInfo, RPCConfig, RecoveryOutcome, SwapStatus, TakerReport,
@@ -364,6 +366,54 @@ impl MakerConnection {
     }
 }
 
+pub(crate) struct TakerBip324Wrapper {
+    protocol: bip324::io::Protocol<TcpStream, TcpStream>,
+}
+
+impl TakerBip324Wrapper {
+    pub fn new(stream: TcpStream, network: bip324::Network) -> Result<Self, ProtocolError> {
+        let reader = stream.try_clone()?;
+        let writer = stream;
+        let protocol = bip324::io::Protocol::new(
+            // TODO
+            network,
+            bip324::Role::Initiator,
+            None,
+            None, // no garbage or decoys
+            reader,
+            writer,
+        )?;
+
+        Ok(Self { protocol })
+    }
+
+    /// Reads a response byte_array from a given stream.
+    /// Response can be any length-appended data, where the first byte is the length of the actual message.
+    pub(crate) fn read_message(&mut self) -> Result<Vec<u8>, NetError> {
+        let payload = self.protocol.read()?;
+        let contents = payload.contents();
+        match payload.packet_type() {
+            bip324::PacketType::Decoy => {
+                // TODO implement proper decoy handling
+                log::info!("Received decoy message");
+                Err(Bip324Error::UnexpectedDecoy.into())
+            }
+            bip324::PacketType::Genuine => Ok(contents.to_vec()),
+        }
+    }
+
+    /// Send a length-appended Protocol or RPC Message through a stream.
+    /// The first byte sent is the length of the actual message.
+    pub(crate) fn send_message(&mut self, message: &impl serde::Serialize) -> Result<(), NetError> {
+        let msg_bytes = serde_cbor::ser::to_vec(message)?;
+        let to_send = Payload::genuine(msg_bytes);
+
+        self.protocol.write(&to_send)?;
+
+        Ok(())
+    }
+}
+
 impl Taker {
     /// Compute the minimum expected output amount for a specific maker hop.
     ///
@@ -405,6 +455,8 @@ pub struct Taker {
     pub(crate) config: TakerInitConfig,
     /// Wallet for managing funds.
     pub(crate) wallet: Arc<RwLock<Wallet>>,
+    /// Bitcoin network that the taker is operating on.
+    pub(crate) network: bitcoin::Network,
     /// Offer book for managing maker offers.
     pub(crate) offerbook: OfferBookHandle,
     /// Watch service for transaction monitoring.
@@ -501,6 +553,12 @@ impl Taker {
         std::fs::create_dir_all(&data_dir)?;
 
         let (wallet, rpc_config) = Self::init_wallet(&config, &data_dir)?;
+        let network = {
+            let rpc = Client::try_from(&rpc_config)?;
+            rpc.get_blockchain_info()
+                .map_err(|e| TakerError::Wallet(e.into()))?
+                .chain
+        };
         let (watch_service, registry, initial_sync_complete) =
             Self::init_watch_service(&config, &rpc_config, &data_dir)?;
         Self::init_taker_config(&config, &data_dir)?;
@@ -510,6 +568,7 @@ impl Taker {
             registry,
             config.socks_port,
             rpc_config,
+            network,
             initial_sync_complete,
         )?;
         let swap_tracker = Arc::new(Mutex::new(SwapTracker::load_or_create(&data_dir)?));
@@ -518,6 +577,7 @@ impl Taker {
         let mut taker = Taker {
             config,
             wallet: Arc::new(RwLock::new(wallet)),
+            network,
             offerbook,
             watch_service,
             offer_sync_handle,
@@ -689,12 +749,14 @@ impl Taker {
         socks_port: u16,
         rpc_config: RPCConfig,
         initial_sync_complete: Arc<AtomicBool>,
+        network: bitcoin::Network,
     ) -> Result<OfferSyncHandle, TakerError> {
         let rest_backend = BitcoinRest::new(rpc_config)?;
         Ok(OfferSyncService::new(
             offerbook.clone(),
             registry,
             socks_port,
+            network,
             rest_backend,
             initial_sync_complete,
         )
@@ -779,6 +841,7 @@ impl Taker {
         });
 
         self.discover_makers()?;
+        log::info!("Discovered {} makers for swap id {}", maker_count, swap_id);
         self.persist_swap(SwapPhase::MakersDiscovered)?;
 
         #[cfg(feature = "integration-test")]
@@ -789,6 +852,10 @@ impl Taker {
             ));
         }
 
+        log::info!(
+            "Negotiating swap details with makers for swap id {}",
+            swap_id
+        );
         self.negotiate_swap_details()?;
         self.persist_swap(SwapPhase::Negotiated)?;
 
@@ -1302,8 +1369,8 @@ impl Taker {
 
         // Fetch the maker's offer before proposing swap details.
         // This gives us the fee schedule for amount verification later.
-        send_message(&mut stream, &TakerToMakerMessage::GetOffer(GetOffer))?;
-        let offer_bytes = read_message(&mut stream)?;
+        stream.send_message(&TakerToMakerMessage::GetOffer(GetOffer))?;
+        let offer_bytes = stream.read_message()?;
         let offer_msg: MakerToTakerMessage = serde_cbor::from_slice(&offer_bytes)?;
         match offer_msg {
             MakerToTakerMessage::Offer(offer) => {
@@ -1344,9 +1411,9 @@ impl Taker {
             refund_locktime_offset,
         };
 
-        send_message(&mut stream, &TakerToMakerMessage::SwapDetails(swap_details))?;
+        stream.send_message(&TakerToMakerMessage::SwapDetails(swap_details))?;
 
-        let msg_bytes = read_message(&mut stream)?;
+        let msg_bytes = stream.read_message()?;
         let msg: MakerToTakerMessage = serde_cbor::from_slice(&msg_bytes)?;
 
         match msg {
@@ -1641,12 +1708,12 @@ impl Taker {
     #[hotpath::measure]
     pub(crate) fn net_handshake(
         &self,
-        stream: &mut TcpStream,
+        stream: &mut TakerBip324Wrapper,
     ) -> Result<ProtocolVersion, TakerError> {
         // Send TakerHello
-        send_message(stream, &TakerToMakerMessage::TakerHello(TakerHello))?;
+        stream.send_message(&TakerToMakerMessage::TakerHello(TakerHello))?;
 
-        let msg_bytes = read_message(stream)?;
+        let msg_bytes = stream.read_message()?;
         let msg: MakerToTakerMessage = serde_cbor::from_slice(&msg_bytes)?;
 
         match msg {
@@ -1669,7 +1736,7 @@ impl Taker {
 
     /// Connect to a maker using either direct connection or Tor proxy.
     #[hotpath::measure]
-    pub(crate) fn net_connect(&self, address: &str) -> Result<TcpStream, TakerError> {
+    pub(crate) fn net_connect(&self, address: &str) -> Result<TakerBip324Wrapper, TakerError> {
         use crate::protocol::common_messages::COINSWAP_PORT;
 
         log::debug!("Connecting to maker at {}", address);
@@ -1704,7 +1771,10 @@ impl Taker {
             .and_then(|_| socket.set_write_timeout(Some(timeout)))
             .map_err(|e| TakerError::General(format!("Failed to set socket timeout: {}", e)))?;
 
-        Ok(socket)
+        let encrypted_protocol =
+            TakerBip324Wrapper::new(socket, self.network).map_err(|e| TakerError::Net(e.into()))?;
+
+        Ok(encrypted_protocol)
     }
 
     /// Finalize the swap by exchanging private keys with all makers.
@@ -1787,9 +1857,9 @@ impl Taker {
             log::info!("Sending privkey to maker {} and awaiting response", i);
 
             let msg = Self::msg_build_handover(protocol, swap_id.clone(), current_privkey);
-            send_message(&mut stream, &msg)?;
+            stream.send_message(&msg)?;
 
-            let msg_bytes = read_message(&mut stream)?;
+            let msg_bytes = stream.read_message()?;
             let msg: MakerToTakerMessage = serde_cbor::from_slice(&msg_bytes)?;
 
             let received_privkey = match msg {

--- a/src/taker/api.rs
+++ b/src/taker/api.rs
@@ -35,8 +35,8 @@ use crate::{
     nostr_coinswap::NOSTR_RELAYS,
     protocol::{
         common_messages::{
-            GetOffer, MakerToTakerMessage, Offer, PrivateKeyHandover, ProtocolVersion, SwapDetails,
-            SwapPrivkey, TakerHello, TakerToMakerMessage,
+            AckSwap, GetOffer, MakerToTakerMessage, Offer, PrivateKeyHandover, ProtocolVersion,
+            SwapDetails, SwapPrivkey, TakerHello, TakerToMakerMessage,
         },
         contract::calculate_pubkey_from_nonce,
     },
@@ -567,8 +567,8 @@ impl Taker {
             registry,
             config.socks_port,
             rpc_config,
-            network,
             initial_sync_complete,
+            network,
         )?;
         let swap_tracker = Arc::new(Mutex::new(SwapTracker::load_or_create(&data_dir)?));
         swap_tracker.lock().unwrap().cleanup_incomplete();
@@ -1416,10 +1416,10 @@ impl Taker {
         let msg: MakerToTakerMessage = serde_cbor::from_slice(&msg_bytes)?;
 
         match msg {
-            MakerToTakerMessage::AckSwapDetails(ack) => {
-                if let Some(tweakable_point) = ack.tweakable_point {
+            MakerToTakerMessage::AckSwap(ack) => match ack {
+                AckSwap::Acknowledged(ack_details) => {
                     let swap = self.swap_state_mut()?;
-                    swap.makers[maker_idx].tweakable_point = Some(tweakable_point);
+                    swap.makers[maker_idx].tweakable_point = Some(ack_details.tweakable_point);
                     swap.makers[maker_idx].protocol = negotiated_protocol;
                     swap.makers[maker_idx].negotiated_timelock = timelock;
                     log::info!("Maker {} accepted swap with tweakable point", maker_idx);
@@ -1435,16 +1435,28 @@ impl Taker {
                         ));
                     }
 
+                    let maker_session_id = ack_details.session_id;
+                    let taker_session_id = stream.protocol.session_id();
+                    if &maker_session_id != taker_session_id {
+                        return Err(TakerError::Net(Bip324Error::SessionIdMismatch.into()));
+                    };
+                    let secp = bitcoin::secp256k1::Secp256k1::new();
+                    let sighash = bitcoin::secp256k1::Message::from_digest(maker_session_id);
+                    secp.verify_ecdsa(
+                        &sighash,
+                        &ack_details.session_id_sig,
+                        &ack_details.tweakable_point.inner,
+                    )
+                    .map_err(|e| TakerError::Net(Bip324Error::SessionIdSigInvalid(e).into()))?;
                     Ok(())
-                } else {
-                    Err(TakerError::General(format!(
-                        "Maker {} rejected swap",
-                        maker_idx
-                    )))
                 }
-            }
+                AckSwap::Rejected => Err(TakerError::General(format!(
+                    "Maker {} rejected swap",
+                    maker_idx
+                ))),
+            },
             _ => Err(TakerError::General(format!(
-                "Unexpected message from maker {}: expected AckSwapDetails",
+                "Unexpected message from maker {}: expected AckSwap",
                 maker_idx
             ))),
         }

--- a/src/taker/api.rs
+++ b/src/taker/api.rs
@@ -371,12 +371,11 @@ pub(crate) struct TakerBip324Wrapper {
 }
 
 impl TakerBip324Wrapper {
-    pub fn new(stream: TcpStream, network: bip324::Network) -> Result<Self, ProtocolError> {
+    pub fn new(stream: TcpStream, network: bitcoin::Network) -> Result<Self, ProtocolError> {
         let reader = stream.try_clone()?;
         let writer = stream;
         let protocol = bip324::io::Protocol::new(
-            // TODO
-            network,
+            network.magic(),
             bip324::Role::Initiator,
             None,
             None, // no garbage or decoys

--- a/src/taker/api.rs
+++ b/src/taker/api.rs
@@ -29,6 +29,7 @@ use bitcoin::{
 use bitcoind::bitcoincore_rpc::json::ListUnspentResultEntry;
 
 use crate::{
+    bip324_stream::Bip324Stream,
     lock_debug,
     maker::nostr::NOSTR_RELAYS,
     protocol::{
@@ -38,10 +39,7 @@ use crate::{
         },
         contract::calculate_pubkey_from_nonce,
     },
-    utill::{
-        estimate_funding_tx_fee_sats, generate_maker_keys, get_taker_dir, read_message,
-        send_message,
-    },
+    utill::{estimate_funding_tx_fee_sats, generate_maker_keys, get_taker_dir},
     wallet::{
         swapcoin::{IncomingSwapCoin, OutgoingSwapCoin, WatchOnlySwapCoin},
         AnyBlockchain, BackendConfig, Blockchain, CoreRpcConfig,
@@ -88,7 +86,7 @@ pub const CONNECT_TIMEOUT_SECS: u64 = 30;
 #[cfg(not(feature = "integration-test"))]
 const MAKER_RESPONSE_TIMEOUT_SECS: u64 = 1800;
 #[cfg(feature = "integration-test")]
-const MAKER_RESPONSE_TIMEOUT_SECS: u64 = 60;
+const MAKER_RESPONSE_TIMEOUT_SECS: u64 = 300;
 
 /// How long the taker waits for a maker's funding to show on-chain before
 /// declaring the swap failed. A live maker broadcasts right after processing;
@@ -322,7 +320,7 @@ pub struct SwapSummary {
 }
 
 /// State for an ongoing swap.
-#[derive(Debug, Clone, Default)]
+#[derive(Debug, Default)]
 pub(crate) struct OngoingSwapState {
     /// Unique swap ID.
     pub(crate) id: String,
@@ -356,7 +354,7 @@ pub(crate) struct OngoingSwapState {
 }
 
 /// Connection state for a maker in the swap route.
-#[derive(Debug, Clone)]
+#[derive(Debug)]
 pub(crate) struct MakerConnection {
     /// Maker's network address.
     pub(crate) address: MakerAddress,
@@ -373,6 +371,8 @@ pub(crate) struct MakerConnection {
     pub(crate) exchange: ExchangeProgress,
     /// Shared finalization milestones (preimage, privkey exchange).
     pub(crate) finalization: FinalizationProgress,
+    /// BIP324 channel to this maker, held across swap
+    pub(crate) stream: Option<Bip324Stream>,
 }
 
 impl MakerConnection {
@@ -590,6 +590,7 @@ impl Taker {
         // key material, so the cleartext passphrase must not linger in the
         // long-lived server config.
         let wallet = Wallet::load_or_init(&wallet_path, blockchain, config.password.take())?;
+        let network = wallet.store.network;
 
         // Init Watch Service
         let (watch_service, registry, initial_sync_complete) =
@@ -612,6 +613,7 @@ impl Taker {
             &offerbook,
             registry,
             config.socks_port,
+            network,
             Arc::new(AnyBlockchain::from_config_with_shutdown(
                 &backend,
                 shutdown.clone(),
@@ -806,6 +808,7 @@ impl Taker {
         offerbook: &OfferBookHandle,
         registry: FileRegistry,
         socks_port: u16,
+        network: bitcoin::Network,
         chain: Arc<AnyBlockchain>,
         initial_sync_complete: Arc<AtomicBool>,
         shutdown: Arc<AtomicBool>,
@@ -814,6 +817,7 @@ impl Taker {
             offerbook.clone(),
             registry,
             socks_port,
+            network,
             chain,
             initial_sync_complete,
             shutdown,
@@ -1354,6 +1358,7 @@ impl Taker {
                         negotiated_timelock: 0,
                         exchange,
                         finalization: FinalizationProgress::default(),
+                        stream: None,
                     }
                 })
                 .collect();
@@ -1417,6 +1422,7 @@ impl Taker {
                         negotiated_timelock: 0,
                         exchange,
                         finalization: FinalizationProgress::default(),
+                        stream: None,
                     }
                 })
                 .collect();
@@ -1518,6 +1524,7 @@ impl Taker {
                             negotiated_timelock: 0,
                             exchange,
                             finalization: FinalizationProgress::default(),
+                            stream: None,
                         };
                         self.swap_state_mut()?.makers[i] = replacement;
                         // Don't increment i — retry with the replacement
@@ -1543,6 +1550,49 @@ impl Taker {
         Ok(())
     }
 
+    /// Take the cached BIP324 stream to `maker_idx`, if any, re-establishing it
+    /// otherwise.
+    ///
+    /// The stream is taken out of the swap state so only one owner holds it at a
+    /// time; it must be given back via [`Self::return_connection`]. If no cached
+    /// stream exists (first contact or a previous phase dropped it), we reconnect,
+    /// redo the handshake, and re-verify the maker's `session_id_sig` against the
+    /// tweakable point cached after `AckSwapDetails`.
+    pub(crate) fn take_connection(&mut self, maker_idx: usize) -> Result<Bip324Stream, TakerError> {
+        let stream = match self.swap_state_mut()?.makers[maker_idx].stream.take() {
+            Some(s) => s,
+            None => {
+                log::warn!("Bip324Stream not found reconnecting");
+                let addr = self.swap_state()?.makers[maker_idx].address.to_string();
+                let mut s = self.net_connect(&addr)?;
+                let tweakable_point = {
+                    let swap = self.swap_state()?;
+                    swap.makers[maker_idx].tweakable_point.ok_or_else(|| {
+                        TakerError::General(
+                            "No cached offer for tweakable point binding check".to_string(),
+                        )
+                    })?
+                };
+
+                let (_, session_id_sig) = self.net_handshake(&mut s)?;
+                s.authenticate(&tweakable_point, &session_id_sig)?;
+                s
+            }
+        };
+        Ok(stream)
+    }
+
+    /// Hand a stream back into the swap state so later phases reuse the same
+    /// authenticated channel instead of paying for a reconnect.
+    pub(crate) fn return_connection(
+        &mut self,
+        maker_idx: usize,
+        stream: Bip324Stream,
+    ) -> Result<(), TakerError> {
+        self.swap_state_mut()?.makers[maker_idx].stream = Some(stream);
+        Ok(())
+    }
+
     /// Negotiate swap details with a single maker at the given route index.
     fn negotiate_with_maker(
         &mut self,
@@ -1557,15 +1607,14 @@ impl Taker {
         log::info!("Connecting to maker {} at {}", maker_idx, maker_address);
 
         let mut stream = self.net_connect(&maker_address)?;
+        let (negotiated_protocol, session_id_sig) = self.net_handshake(&mut stream)?;
 
-        let negotiated_protocol = self.net_handshake(&mut stream)?;
         log::info!("Handshake complete, protocol: {:?}", negotiated_protocol);
 
         // Fetch the maker's offer before proposing swap details.
         // This gives us the fee schedule for amount verification later.
-        send_message(&mut stream, &TakerToMakerMessage::GetOffer(GetOffer))?;
-        let offer_bytes = read_message(&mut stream)?;
-        let offer_msg: MakerToTakerMessage = serde_cbor::from_slice(&offer_bytes)?;
+        stream.send_message(&TakerToMakerMessage::GetOffer(GetOffer))?;
+        let offer_msg: MakerToTakerMessage = stream.read_message()?;
         match offer_msg {
             MakerToTakerMessage::Offer(offer) => {
                 log::info!(
@@ -1575,6 +1624,20 @@ impl Taker {
                     offer.amount_relative_fee_pct,
                     offer.time_relative_fee_pct
                 );
+                if let Some(expected_tweakable_point) = self.swap_state()?.makers[maker_idx]
+                    .offer
+                    .as_ref()
+                    .map(|offer| offer.tweakable_point)
+                {
+                    if offer.tweakable_point != expected_tweakable_point {
+                        return Err(TakerError::General(format!(
+                            "Maker {} changed offer tweakable point: expected {}, got {}",
+                            maker_idx, expected_tweakable_point, offer.tweakable_point,
+                        )));
+                    }
+                }
+                stream.authenticate(&offer.tweakable_point, &session_id_sig)?;
+
                 Self::validate_offer(&offer, maker_idx, send_amount)?;
                 // A repricing since the payment quote would silently move the
                 // receiver's amount; abort while nothing is funded. Bitwise
@@ -1631,17 +1694,40 @@ impl Taker {
             swap_details.amount = amount;
         }
 
-        send_message(
-            &mut stream,
-            &TakerToMakerMessage::SwapDetails(swap_details.clone()),
-        )?;
+        stream.send_message(&TakerToMakerMessage::SwapDetails(swap_details.clone()))?;
 
-        let msg_bytes = read_message(&mut stream)?;
-        let msg: MakerToTakerMessage = serde_cbor::from_slice(&msg_bytes)?;
+        let msg: MakerToTakerMessage = stream.read_message()?;
+
+        // Cache the verified channel for the contract-exchange and finalization phases
+        self.return_connection(maker_idx, stream)?;
 
         match msg {
             MakerToTakerMessage::AckSwapDetails(ack) => {
+                #[cfg(feature = "integration-test")]
+                if self.behavior == TakerBehavior::CloseAtAckResponse {
+                    log::warn!(
+                        "Test behavior: closing after receiving AckSwapDetails from maker {}",
+                        maker_idx
+                    );
+                    return Err(TakerError::General(
+                        "Test: closing at ack response".to_string(),
+                    ));
+                }
+
                 if let Some(tweakable_point) = ack.tweakable_point {
+                    let swap = self.swap_state()?;
+                    let offer = swap.makers[maker_idx].offer.as_ref().ok_or_else(|| {
+                        TakerError::General(
+                            "No cached offer for tweakable point binding check".to_string(),
+                        )
+                    })?;
+                    if tweakable_point != offer.tweakable_point {
+                        return Err(TakerError::General(format!(
+                            "AckSwap tweakable point mismatch: expected {}, got {}",
+                            offer.tweakable_point, tweakable_point,
+                        )));
+                    }
+
                     let swap = self.swap_state_mut()?;
                     swap.makers[maker_idx].tweakable_point = Some(tweakable_point);
                     swap.makers[maker_idx].protocol = negotiated_protocol;
@@ -1697,8 +1783,9 @@ impl Taker {
                     )))
                 }
             }
+
             _ => Err(TakerError::General(format!(
-                "Unexpected message from maker {}: expected AckSwapDetails",
+                "Unexpected message from maker {}: expected AckSwap",
                 maker_idx
             ))),
         }
@@ -1712,13 +1799,10 @@ impl Taker {
     ) -> Result<MakerToTakerMessage, TakerError> {
         let mut stream = self.net_connect(maker_address)?;
         self.net_handshake(&mut stream)?;
-        send_message(&mut stream, &TakerToMakerMessage::GetOffer(GetOffer))?;
-        read_message(&mut stream)?;
-        send_message(
-            &mut stream,
-            &TakerToMakerMessage::SwapDetails(details.clone()),
-        )?;
-        Ok(serde_cbor::from_slice(&read_message(&mut stream)?)?)
+        stream.send_message(&TakerToMakerMessage::GetOffer(GetOffer))?;
+        stream.read_message::<MakerToTakerMessage>()?;
+        stream.send_message(&TakerToMakerMessage::SwapDetails(details.clone()))?;
+        Ok(stream.read_message::<MakerToTakerMessage>()?)
     }
 
     /// Validate a maker's offer for fee sanity and size limits.
@@ -1816,6 +1900,7 @@ impl Taker {
             negotiated_timelock: 0,
             exchange,
             finalization: FinalizationProgress::default(),
+            stream: None,
         };
         self.swap_state_mut()?.makers[target_idx] = replacement;
 
@@ -2011,21 +2096,24 @@ impl Taker {
     }
 
     /// Perform handshake with a maker and verify protocol support.
+    ///
+    /// Returns the negotiated protocol version along with the maker's
+    /// `session_id_sig`, which the caller verifies against the maker's
+    /// tweakable point to authenticate the BIP324 channel (anti-MitM).
     pub(crate) fn net_handshake(
         &self,
-        stream: &mut TcpStream,
-    ) -> Result<ProtocolVersion, TakerError> {
+        stream: &mut Bip324Stream,
+    ) -> Result<(ProtocolVersion, bitcoin::secp256k1::ecdsa::Signature), TakerError> {
         // Send TakerHello
-        send_message(stream, &TakerToMakerMessage::TakerHello(TakerHello))?;
+        stream.send_message(&TakerToMakerMessage::TakerHello(TakerHello))?;
 
-        let msg_bytes = read_message(stream)?;
-        let msg: MakerToTakerMessage = serde_cbor::from_slice(&msg_bytes)?;
+        let msg: MakerToTakerMessage = stream.read_message()?;
 
         match msg {
             MakerToTakerMessage::MakerHello(maker_hello) => {
                 let desired = self.swap_state()?.params.protocol;
                 if maker_hello.supported_protocols.contains(&desired) {
-                    Ok(desired)
+                    Ok((desired, maker_hello.session_id_sig))
                 } else {
                     Err(TakerError::General(format!(
                         "Maker does not support {:?}. Supported: {:?}",
@@ -2040,9 +2128,10 @@ impl Taker {
     }
 
     /// Connect to a maker using either direct connection or Tor proxy.
-    pub(crate) fn net_connect(&self, address: &str) -> Result<TcpStream, TakerError> {
+    pub(crate) fn net_connect(&self, address: &str) -> Result<Bip324Stream, TakerError> {
         log::debug!("Connecting to maker at {}", address);
         let timeout = Duration::from_secs(CONNECT_TIMEOUT_SECS);
+        let network = self.read_wallet()?.store.network;
 
         #[cfg(feature = "integration-test")]
         let socket = TcpStream::connect(address)
@@ -2076,7 +2165,9 @@ impl Taker {
             .and_then(|_| socket.set_write_timeout(Some(timeout)))
             .map_err(|e| TakerError::General(format!("Failed to set socket timeout: {}", e)))?;
 
-        Ok(socket)
+        // Wrap the socket in the BIP324 transport: all application messages now
+        // travel as encrypted, genuine payloads over this channel.
+        Ok(Bip324Stream::new(socket, network, bip324::Role::Initiator)?)
     }
 
     /// Connect to every maker in the route and start the heartbeat that keeps
@@ -2191,18 +2282,14 @@ impl Taker {
         }
 
         for i in 0..num_makers {
-            let maker_address = self.swap_state()?.makers[i].address.to_string();
-            let mut stream = self.net_connect(&maker_address)?;
-
-            self.net_handshake(&mut stream)?;
+            let mut stream = self.take_connection(i)?;
 
             log::info!("Sending privkey to maker {} and awaiting response", i);
 
             let msg = Self::msg_build_handover(protocol, swap_id.clone(), &current_privkeys);
-            send_message(&mut stream, &msg)?;
+            stream.send_message(&msg)?;
 
-            let msg_bytes = read_message(&mut stream)?;
-            let msg: MakerToTakerMessage = serde_cbor::from_slice(&msg_bytes)?;
+            let msg: MakerToTakerMessage = stream.read_message()?;
 
             let received_privkeys: Vec<SecretKey> = match msg {
                 MakerToTakerMessage::LegacyPrivateKeyHandover(handover)
@@ -2273,6 +2360,9 @@ impl Taker {
             }
 
             current_privkeys = received_privkeys;
+
+            // Cache the channel for any subsequent retry on this maker.
+            self.return_connection(i, stream)?;
         }
 
         Ok(())

--- a/src/taker/background_services.rs
+++ b/src/taker/background_services.rs
@@ -584,7 +584,10 @@ pub(crate) struct RouteHeartbeat {
 
 impl RouteHeartbeat {
     /// Spawn the heartbeat thread over pre-connected, handshaked streams.
-    pub(crate) fn start(swap_id: &str, streams: Vec<std::net::TcpStream>) -> std::io::Result<Self> {
+    pub(crate) fn start(
+        swap_id: &str,
+        mut streams: Vec<crate::bip324_stream::Bip324Stream>,
+    ) -> std::io::Result<Self> {
         let (stop, stop_rx) = mpsc::channel();
         let keepalive =
             crate::protocol::common_messages::TakerToMakerMessage::WaitingFundingConfirmation(
@@ -592,19 +595,16 @@ impl RouteHeartbeat {
             );
         let handle = thread::Builder::new()
             .name("Route heartbeat".to_string())
-            .spawn(move || {
-                let mut streams = streams;
-                loop {
-                    for stream in streams.iter_mut() {
-                        if stop_rx.try_recv().is_ok() {
-                            return;
-                        }
-                        let _ = crate::utill::send_message(stream, &keepalive);
+            .spawn(move || loop {
+                for stream in streams.iter_mut() {
+                    if stop_rx.try_recv().is_ok() {
+                        return;
                     }
-                    match stop_rx.recv_timeout(super::api::ROUTE_HEARTBEAT_INTERVAL) {
-                        Err(mpsc::RecvTimeoutError::Timeout) => {}
-                        Ok(()) | Err(mpsc::RecvTimeoutError::Disconnected) => return,
-                    }
+                    let _ = stream.send_message(&keepalive);
+                }
+                match stop_rx.recv_timeout(super::api::ROUTE_HEARTBEAT_INTERVAL) {
+                    Err(mpsc::RecvTimeoutError::Timeout) => {}
+                    Ok(()) | Err(mpsc::RecvTimeoutError::Disconnected) => return,
                 }
             })?;
         Ok(Self {

--- a/src/taker/error.rs
+++ b/src/taker/error.rs
@@ -111,3 +111,8 @@ impl From<WatcherError> for TakerError {
         Self::Watcher(value)
     }
 }
+impl From<bip324::io::ProtocolError> for TakerError {
+    fn from(value: bip324::io::ProtocolError) -> Self {
+        Self::Net(value.into())
+    }
+}

--- a/src/taker/error.rs
+++ b/src/taker/error.rs
@@ -120,3 +120,8 @@ impl From<WatcherError> for TakerError {
         Self::Watcher(value)
     }
 }
+impl From<bip324::io::ProtocolError> for TakerError {
+    fn from(value: bip324::io::ProtocolError) -> Self {
+        Self::Net(value.into())
+    }
+}

--- a/src/taker/legacy_swap.rs
+++ b/src/taker/legacy_swap.rs
@@ -1,6 +1,6 @@
 //! Legacy (ECDSA) specific swap methods for the Taker.
 
-use std::{net::TcpStream, time::Duration};
+use std::time::Duration;
 
 use bitcoin::{
     hashes::{hash160::Hash as Hash160, Hash},
@@ -23,7 +23,8 @@ use crate::{
             RespContractSigsForRecvrAndSender, SenderContractTxInfo,
         },
     },
-    utill::{generate_keypair, generate_maker_keys, read_message, send_message, MIN_FEE_RATE},
+    taker::api::TakerBip324Wrapper,
+    utill::{generate_keypair, generate_maker_keys, MIN_FEE_RATE},
     wallet::{
         swapcoin::{IncomingSwapCoin, OutgoingSwapCoin, WatchOnlySwapCoin},
         Wallet, WalletError,
@@ -798,7 +799,7 @@ impl Taker {
     #[hotpath::measure]
     fn exchange_req_sender_sigs(
         &self,
-        stream: &mut TcpStream,
+        stream: &mut TakerBip324Wrapper,
         swap_id: &str,
         outgoing_swapcoins: &[OutgoingSwapCoin],
         locktime: u16,
@@ -855,9 +856,9 @@ impl Taker {
             locktime,
         };
 
-        send_message(stream, &TakerToMakerMessage::ReqContractSigsForSender(req))?;
+        stream.send_message(&TakerToMakerMessage::ReqContractSigsForSender(req))?;
 
-        let msg_bytes = read_message(stream)?;
+        let msg_bytes = stream.read_message()?;
         let msg: MakerToTakerMessage = serde_cbor::from_slice(&msg_bytes)?;
 
         match msg {
@@ -890,7 +891,7 @@ impl Taker {
     #[hotpath::measure]
     fn exchange_send_proof_of_funding(
         &self,
-        stream: &mut TcpStream,
+        stream: &mut TakerBip324Wrapper,
         swap_id: &str,
         maker_idx: usize,
         funding_txs: &[Transaction],
@@ -961,9 +962,9 @@ impl Taker {
             contract_feerate: MIN_FEE_RATE,
         };
 
-        send_message(stream, &TakerToMakerMessage::ProofOfFunding(pof))?;
+        stream.send_message(&TakerToMakerMessage::ProofOfFunding(pof))?;
 
-        let msg_bytes = read_message(stream)?;
+        let msg_bytes = stream.read_message()?;
         let msg: MakerToTakerMessage = serde_cbor::from_slice(&msg_bytes)?;
 
         match msg {
@@ -1001,7 +1002,7 @@ impl Taker {
     #[hotpath::measure]
     fn exchange_send_combined_sigs(
         &self,
-        stream: &mut TcpStream,
+        stream: &mut TakerBip324Wrapper,
         swap_id: &str,
         receivers_sigs: Vec<bitcoin::ecdsa::Signature>,
         senders_sigs: Vec<bitcoin::ecdsa::Signature>,
@@ -1012,10 +1013,9 @@ impl Taker {
             senders_sigs,
         };
 
-        send_message(
-            stream,
-            &TakerToMakerMessage::RespContractSigsForRecvrAndSender(resp),
-        )?;
+        stream.send_message(&TakerToMakerMessage::RespContractSigsForRecvrAndSender(
+            resp,
+        ))?;
 
         log::info!(
             "Sent RespContractSigsForRecvrAndSender for swap {}",
@@ -1028,7 +1028,7 @@ impl Taker {
     #[hotpath::measure]
     fn exchange_req_sender_sigs_forwarded(
         &self,
-        stream: &mut TcpStream,
+        stream: &mut TakerBip324Wrapper,
         swap_id: &str,
         senders_info: &[SenderContractTxInfo],
         hashvalue: Hash160,
@@ -1054,9 +1054,9 @@ impl Taker {
             locktime,
         };
 
-        send_message(stream, &TakerToMakerMessage::ReqContractSigsForSender(req))?;
+        stream.send_message(&TakerToMakerMessage::ReqContractSigsForSender(req))?;
 
-        let msg_bytes = read_message(stream)?;
+        let msg_bytes = stream.read_message()?;
         let msg: MakerToTakerMessage = serde_cbor::from_slice(&msg_bytes)?;
 
         match msg {
@@ -1077,7 +1077,7 @@ impl Taker {
     #[hotpath::measure]
     fn exchange_req_receiver_sigs(
         &self,
-        stream: &mut TcpStream,
+        stream: &mut TakerBip324Wrapper,
         swap_id: &str,
         receivers_txs: &[Transaction],
         prev_senders_info: &[SenderContractTxInfo],
@@ -1097,9 +1097,9 @@ impl Taker {
             txs,
         };
 
-        send_message(stream, &TakerToMakerMessage::ReqContractSigsForRecvr(req))?;
+        stream.send_message(&TakerToMakerMessage::ReqContractSigsForRecvr(req))?;
 
-        let msg_bytes = read_message(stream)?;
+        let msg_bytes = stream.read_message()?;
         let msg: MakerToTakerMessage = serde_cbor::from_slice(&msg_bytes)?;
 
         match msg {

--- a/src/taker/legacy_swap.rs
+++ b/src/taker/legacy_swap.rs
@@ -9,6 +9,7 @@ use bitcoin::{
 };
 
 use crate::{
+    bip324_stream::Bip324Stream,
     protocol::{
         common_messages::{MakerToTakerMessage, TakerToMakerMessage},
         contract::{
@@ -22,7 +23,7 @@ use crate::{
             RespContractSigsForRecvrAndSender, SenderContractTxInfo,
         },
     },
-    utill::{generate_keypair, generate_maker_keys, read_message, send_message, MIN_FEE_RATE},
+    utill::{generate_keypair, generate_maker_keys, MIN_FEE_RATE},
     wallet::{
         swapcoin::{IncomingSwapCoin, OutgoingSwapCoin, WatchOnlySwapCoin},
         Wallet,
@@ -168,13 +169,12 @@ impl Taker {
                 maker_address
             );
 
-            // Connect to this maker
-            let mut stream = self.net_connect(&maker_address)?;
-            self.net_handshake(&mut stream)?;
+            // Reuse the authenticated channel negotiated earlier instead of
+            // opening a fresh (unauthenticated) connection per phase.
+            let mut stream = self.take_connection(maker_idx)?;
             self.swap_state_mut()?.makers[maker_idx]
                 .legacy_exchange_mut()?
                 .connected = true;
-            drop(stream);
             // Determine our position
             let is_first_peer = maker_idx == 0;
             let is_last_peer = maker_idx == maker_count - 1;
@@ -287,7 +287,7 @@ impl Taker {
                     maker_idx
                 );
                 let sender_sigs = self.exchange_req_sender_sigs(
-                    &maker_address,
+                    &mut stream,
                     &swap_id,
                     &self.swap_state()?.outgoing_swapcoins,
                     outgoing_locktime,
@@ -434,7 +434,7 @@ impl Taker {
 
             let (receivers_contract_txs, senders_contract_txs_info) = self
                 .exchange_send_proof_of_funding(
-                    &maker_address,
+                    &mut stream,
                     &swap_id,
                     maker_idx,
                     &funding_txs,
@@ -519,19 +519,21 @@ impl Taker {
                 // with the spare's keys for the next hop.
                 log::info!("Requesting sender signatures from next maker");
                 let forward_result = (|| -> Result<Vec<bitcoin::ecdsa::Signature>, TakerError> {
-                    let next_addr = self.swap_state()?.makers[maker_idx + 1].address.to_string();
-
+                    let next_idx = maker_idx + 1;
                     let hashvalue = Hash160::hash(&self.swap_state()?.preimage);
                     let next_locktime =
                         self.swap_state()?.makers[maker_idx + 1].negotiated_timelock as u16;
 
-                    self.exchange_req_sender_sigs_forwarded(
-                        &next_addr,
+                    let mut next_stream = self.take_connection(next_idx)?;
+                    let sigs = self.exchange_req_sender_sigs_forwarded(
+                        &mut next_stream,
                         &swap_id,
                         &senders_contract_txs_info,
                         hashvalue,
                         next_locktime,
-                    )
+                    )?;
+                    self.return_connection(next_idx, next_stream)?;
+                    Ok(sigs)
                 })();
 
                 match forward_result {
@@ -599,17 +601,18 @@ impl Taker {
             } else {
                 log::info!("Requesting receiver signatures from previous maker");
                 // For subsequent hops, request from previous maker
-                let prev_maker_address =
-                    self.swap_state()?.makers[maker_idx - 1].address.to_string();
-
-                self.exchange_req_receiver_sigs(
-                    &prev_maker_address,
+                let prev_idx = maker_idx - 1;
+                let mut prev_stream = self.take_connection(prev_idx)?;
+                let receivers_sigs = self.exchange_req_receiver_sigs(
+                    &mut prev_stream,
                     &swap_id,
                     &receivers_contract_txs,
                     prev_senders_info
                         .as_ref()
                         .ok_or(ProtocolError::General("missing previous hop sender info"))?,
-                )?
+                )?;
+                self.return_connection(prev_idx, prev_stream)?;
+                receivers_sigs
             };
             self.swap_state_mut()?.makers[maker_idx]
                 .legacy_exchange_mut()?
@@ -619,12 +622,7 @@ impl Taker {
                 "Sending RespContractSigsForRecvrAndSender to maker {}",
                 maker_idx
             );
-            self.exchange_send_combined_sigs(
-                &maker_address,
-                &swap_id,
-                receivers_sigs,
-                senders_sigs,
-            )?;
+            self.exchange_send_combined_sigs(&mut stream, &swap_id, receivers_sigs, senders_sigs)?;
             self.swap_state_mut()?.makers[maker_idx]
                 .legacy_exchange_mut()?
                 .combined_sigs_sent = true;
@@ -633,6 +631,7 @@ impl Taker {
             // Store this maker's outgoing info for next hop
             prev_senders_info = Some(senders_contract_txs_info.clone());
 
+            self.return_connection(maker_idx, stream)?;
             // For non-first hops, the taker doesn't own these contracts — track as watch-only
             if !is_first_peer {
                 let watchonly_coins: Vec<WatchOnlySwapCoin> = senders_contract_txs_info
@@ -815,9 +814,8 @@ impl Taker {
             // Request the last maker's contract signature on the incoming contracts.
             // This allows the taker to broadcast the incoming contract tx during recovery
             // (for hashlock spending) without depending on the Maker.
-            let last_maker_address = self.swap_state()?.makers[maker_count - 1]
-                .address
-                .to_string();
+            let last_idx = maker_count - 1;
+            let last_maker_address = self.swap_state()?.makers[last_idx].address.to_string();
             log::info!(
                 "Requesting receiver contract sigs from last maker: {}",
                 last_maker_address
@@ -827,12 +825,14 @@ impl Taker {
                 .map(|info| info.contract_tx.clone())
                 .collect();
 
+            let mut last_stream = self.take_connection(last_idx)?;
             let receiver_sigs = self.exchange_req_receiver_sigs(
-                &last_maker_address,
+                &mut last_stream,
                 &swap_id,
                 &incoming_contract_txs,
                 last_senders_info,
             )?;
+            self.return_connection(last_idx, last_stream)?;
 
             // Store the maker's signatures on the incoming swapcoins
             let swap = self.swap_state_mut()?;
@@ -890,12 +890,11 @@ impl Taker {
     /// Request contract signatures for sender from a maker.
     fn exchange_req_sender_sigs(
         &self,
-        maker_address: &str,
+        stream: &mut Bip324Stream,
         swap_id: &str,
         outgoing_swapcoins: &[OutgoingSwapCoin],
         locktime: u16,
     ) -> Result<Vec<bitcoin::ecdsa::Signature>, TakerError> {
-        let mut stream = self.net_connect(maker_address)?;
         let secp = Secp256k1::new();
 
         // Use the correct nonces from swap state — these are the nonces that
@@ -942,13 +941,9 @@ impl Taker {
             locktime,
         };
 
-        send_message(
-            &mut stream,
-            &TakerToMakerMessage::ReqContractSigsForSender(req),
-        )?;
+        stream.send_message(&TakerToMakerMessage::ReqContractSigsForSender(req))?;
 
-        let msg_bytes = read_message(&mut stream)?;
-        let msg: MakerToTakerMessage = serde_cbor::from_slice(&msg_bytes)?;
+        let msg: MakerToTakerMessage = stream.read_message()?;
 
         match msg {
             MakerToTakerMessage::RespContractSigsForSender(resp) => {
@@ -1043,7 +1038,7 @@ impl Taker {
     #[allow(clippy::too_many_arguments)]
     fn exchange_send_proof_of_funding(
         &self,
-        maker_address: &str,
+        stream: &mut Bip324Stream,
         swap_id: &str,
         maker_idx: usize,
         funding_txs: &[Transaction],
@@ -1057,7 +1052,6 @@ impl Taker {
         next_hashlock_nonces: &[SecretKey],
         refund_locktime: u16,
     ) -> Result<(Vec<Transaction>, Vec<SenderContractTxInfo>), TakerError> {
-        let mut stream = self.net_connect(maker_address)?;
         let confirmed_funding_txes: Vec<FundingTxInfo> = {
             funding_txs
                 .iter()
@@ -1181,10 +1175,9 @@ impl Taker {
             contract_feerate: MIN_FEE_RATE,
         };
 
-        send_message(&mut stream, &TakerToMakerMessage::ProofOfFunding(pof))?;
+        stream.send_message(&TakerToMakerMessage::ProofOfFunding(pof))?;
 
-        let msg_bytes = read_message(&mut stream)?;
-        let msg: MakerToTakerMessage = serde_cbor::from_slice(&msg_bytes)?;
+        let msg: MakerToTakerMessage = stream.read_message()?;
 
         match msg {
             MakerToTakerMessage::ReqContractSigsAsRecvrAndSender(req) => {
@@ -1224,22 +1217,20 @@ impl Taker {
     /// Send collected signatures for both receiver and sender contracts (Legacy protocol).
     fn exchange_send_combined_sigs(
         &self,
-        maker_address: &str,
+        stream: &mut Bip324Stream,
         swap_id: &str,
         receivers_sigs: Vec<bitcoin::ecdsa::Signature>,
         senders_sigs: Vec<bitcoin::ecdsa::Signature>,
     ) -> Result<(), TakerError> {
-        let mut stream = self.net_connect(maker_address)?;
         let resp = RespContractSigsForRecvrAndSender {
             id: swap_id.to_string(),
             receivers_sigs,
             senders_sigs,
         };
 
-        send_message(
-            &mut stream,
-            &TakerToMakerMessage::RespContractSigsForRecvrAndSender(resp),
-        )?;
+        stream.send_message(&TakerToMakerMessage::RespContractSigsForRecvrAndSender(
+            resp,
+        ))?;
 
         log::info!(
             "Sent RespContractSigsForRecvrAndSender for swap {}",
@@ -1251,13 +1242,12 @@ impl Taker {
     /// Request sender contract signatures using SenderContractTxInfo.
     fn exchange_req_sender_sigs_forwarded(
         &self,
-        maker_address: &str,
+        stream: &mut Bip324Stream,
         swap_id: &str,
         senders_info: &[SenderContractTxInfo],
         hashvalue: Hash160,
         locktime: u16,
     ) -> Result<Vec<bitcoin::ecdsa::Signature>, TakerError> {
-        let mut stream = self.net_connect(maker_address)?;
         // Build ContractTxInfoForSender from SenderContractTxInfo
         let txs_info: Vec<ContractTxInfoForSender> = senders_info
             .iter()
@@ -1278,13 +1268,9 @@ impl Taker {
             locktime,
         };
 
-        send_message(
-            &mut stream,
-            &TakerToMakerMessage::ReqContractSigsForSender(req),
-        )?;
+        stream.send_message(&TakerToMakerMessage::ReqContractSigsForSender(req))?;
 
-        let msg_bytes = read_message(&mut stream)?;
-        let msg: MakerToTakerMessage = serde_cbor::from_slice(&msg_bytes)?;
+        let msg: MakerToTakerMessage = stream.read_message()?;
 
         match msg {
             MakerToTakerMessage::RespContractSigsForSender(resp) => {
@@ -1303,12 +1289,11 @@ impl Taker {
     /// Request receiver signatures from previous maker.
     fn exchange_req_receiver_sigs(
         &self,
-        maker_address: &str,
+        stream: &mut Bip324Stream,
         swap_id: &str,
         receivers_txs: &[Transaction],
         prev_senders_info: &[SenderContractTxInfo],
     ) -> Result<Vec<bitcoin::ecdsa::Signature>, TakerError> {
-        let mut stream = self.net_connect(maker_address)?;
         // Build ContractTxInfoForRecvr for each receiver contract
         let txs: Vec<ContractTxInfoForRecvr> = receivers_txs
             .iter()
@@ -1324,13 +1309,9 @@ impl Taker {
             txs,
         };
 
-        send_message(
-            &mut stream,
-            &TakerToMakerMessage::ReqContractSigsForRecvr(req),
-        )?;
+        stream.send_message(&TakerToMakerMessage::ReqContractSigsForRecvr(req))?;
 
-        let msg_bytes = read_message(&mut stream)?;
-        let msg: MakerToTakerMessage = serde_cbor::from_slice(&msg_bytes)?;
+        let msg: MakerToTakerMessage = stream.read_message()?;
 
         match msg {
             MakerToTakerMessage::RespContractSigsForRecvr(resp) => {

--- a/src/taker/offers.rs
+++ b/src/taker/offers.rs
@@ -19,6 +19,7 @@ use std::{
     time::{Duration, SystemTime, UNIX_EPOCH},
 };
 
+use bip324::Network;
 use serde::{Deserialize, Serialize};
 use socks::Socks5Stream;
 
@@ -31,7 +32,7 @@ use crate::{
         },
         error::ProtocolError,
     },
-    utill::{read_message, send_message},
+    taker::api::TakerBip324Wrapper,
     wallet::verify_fidelity_checks,
     watch_tower::{registry_storage::FileRegistry, rest_backend::BitcoinRest},
 };
@@ -374,6 +375,7 @@ pub struct OfferSyncService {
     offerbook: OfferBookHandle,
     registry: FileRegistry,
     socks_port: u16,
+    network: Network,
     rest_backend: BitcoinRest,
     /// Set to `true` by Nostr discovery after the first EOSE is received.
     initial_sync_complete: Arc<AtomicBool>,
@@ -412,6 +414,7 @@ impl OfferSyncService {
         offerbook: OfferBookHandle,
         registry: FileRegistry,
         socks_port: u16,
+        network: Network,
         rest_backend: BitcoinRest,
         initial_sync_complete: Arc<AtomicBool>,
     ) -> Self {
@@ -419,6 +422,7 @@ impl OfferSyncService {
             offerbook,
             registry,
             socks_port,
+            network,
             rest_backend,
             initial_sync_complete,
         }
@@ -471,7 +475,6 @@ impl OfferSyncService {
         self.offerbook
             .last_sync_ts
             .store(finished_at, Ordering::Relaxed);
-
         Ok(())
     }
 
@@ -819,9 +822,13 @@ impl TryFrom<String> for MakerAddress {
 }
 
 impl MakerAddress {
-    fn download_offer_with_retries(self, socks_port: u16) -> Option<OfferAndAddress> {
+    fn download_offer_with_retries(
+        self,
+        socks_port: u16,
+        network: Network,
+    ) -> Option<OfferAndAddress> {
         for attempt in 1..=FIRST_CONNECT_ATTEMPTS {
-            match self.clone().download_offer_auto(socks_port) {
+            match self.clone().download_offer_auto(socks_port, network) {
                 Ok(offer) => return Some(offer),
                 Err(e) if attempt < FIRST_CONNECT_ATTEMPTS => {
                     log::debug!(
@@ -841,8 +848,12 @@ impl MakerAddress {
         None
     }
 
-    fn download_offer_auto(self, socks_port: u16) -> Result<OfferAndAddress, TakerError> {
-        let (offer, protocol) = self.fetch_offer(socks_port)?;
+    fn download_offer_auto(
+        self,
+        socks_port: u16,
+        network: Network,
+    ) -> Result<OfferAndAddress, TakerError> {
+        let (offer, protocol) = self.fetch_offer(socks_port, network)?;
         Ok(OfferAndAddress {
             offer,
             address: self,
@@ -852,12 +863,16 @@ impl MakerAddress {
     }
 
     /// Download a single offer from a maker.
-    fn fetch_offer(&self, socks_port: u16) -> Result<(Offer, MakerProtocol), TakerError> {
+    fn fetch_offer(
+        &self,
+        socks_port: u16,
+        network: Network,
+    ) -> Result<(Offer, MakerProtocol), TakerError> {
         use crate::protocol::common_messages::COINSWAP_PORT;
 
         log::debug!("Downloading offer from maker: {}", self);
 
-        let mut socket = if cfg!(feature = "integration-test") {
+        let socket = if cfg!(feature = "integration-test") {
             // Integration test: self.0 is "ip:port"
             TcpStream::connect(self.to_string())?
         } else {
@@ -870,12 +885,14 @@ impl MakerAddress {
         socket.set_read_timeout(Some(Duration::from_secs(FIRST_CONNECT_ATTEMPT_TIMEOUT_SEC)))?;
         socket.set_write_timeout(Some(Duration::from_secs(FIRST_CONNECT_ATTEMPT_TIMEOUT_SEC)))?;
 
+        let mut wrapper = TakerBip324Wrapper::new(socket, network)?;
+
         // Send TakerHello
         let taker_hello = RouterTakerToMakerMessage::TakerHello(RouterTakerHello);
-        send_message(&mut socket, &taker_hello)?;
+        wrapper.send_message(&taker_hello)?;
 
         // Read MakerHello
-        let msg_bytes = read_message(&mut socket)?;
+        let msg_bytes = wrapper.read_message()?;
         let msg: RouterMakerToTakerMessage = serde_cbor::from_slice(&msg_bytes)?;
 
         match msg {
@@ -893,10 +910,10 @@ impl MakerAddress {
 
         // Send GetOffer
         let get_offer = RouterTakerToMakerMessage::GetOffer(RouterGetOffer);
-        send_message(&mut socket, &get_offer)?;
+        wrapper.send_message(&get_offer)?;
 
         // Read Offer
-        let offer_bytes = read_message(&mut socket)?;
+        let offer_bytes = wrapper.read_message()?;
         let offer_msg: RouterMakerToTakerMessage = serde_cbor::from_slice(&offer_bytes)?;
 
         let router_offer = match offer_msg {

--- a/src/taker/offers.rs
+++ b/src/taker/offers.rs
@@ -491,6 +491,7 @@ impl OfferSyncService {
         let offerbook_path = self.offerbook.path.clone();
         let socks_port = self.socks_port;
         let rest_backend = self.rest_backend.clone();
+        let network = self.network;
 
         let mut handles = Vec::with_capacity(workers);
 
@@ -514,7 +515,10 @@ impl OfferSyncService {
                         .unwrap_or(Duration::ZERO)
                         .as_secs();
 
-                    match addr.clone().download_offer_with_retries(socks_port) {
+                    match addr
+                        .clone()
+                        .download_offer_with_retries(socks_port, network)
+                    {
                         Some(oa) => {
                             let verified = verify_fidelity_with_backend(
                                 &rest_backend,

--- a/src/taker/offers.rs
+++ b/src/taker/offers.rs
@@ -19,7 +19,7 @@ use std::{
     time::{Duration, SystemTime, UNIX_EPOCH},
 };
 
-use bip324::Network;
+use bitcoin::Network;
 use serde::{Deserialize, Serialize};
 use socks::Socks5Stream;
 

--- a/src/taker/offers.rs
+++ b/src/taker/offers.rs
@@ -19,10 +19,11 @@ use std::{
     time::{Duration, SystemTime, UNIX_EPOCH},
 };
 
-use bitcoin::{OutPoint, Txid};
+use bitcoin::{Network, OutPoint, Txid};
 use serde::{Deserialize, Serialize};
 
 use crate::{
+    bip324_stream::Bip324Stream,
     lock_debug,
     protocol::{
         common_messages::{
@@ -32,7 +33,6 @@ use crate::{
         },
         error::ProtocolError,
     },
-    utill::{read_message, send_message},
     wallet::{verify_fidelity_checks, AnyBlockchain, Blockchain, FidelityBond, WalletError},
     watch_tower::registry_storage::FileRegistry,
 };
@@ -411,6 +411,7 @@ pub struct OfferSyncService {
     offerbook: OfferBookHandle,
     registry: FileRegistry,
     socks_port: u16,
+    network: Network,
     /// Shared so per-maker offer-fetch workers can each hold a handle.
     blockchain: Arc<AnyBlockchain>,
     /// Set to `true` by Nostr discovery after the first EOSE is received.
@@ -529,6 +530,7 @@ impl OfferSyncService {
         offerbook: OfferBookHandle,
         registry: FileRegistry,
         socks_port: u16,
+        network: Network,
         blockchain: Arc<AnyBlockchain>,
         initial_sync_complete: Arc<AtomicBool>,
         shutdown: Arc<AtomicBool>,
@@ -537,6 +539,7 @@ impl OfferSyncService {
             offerbook,
             registry,
             socks_port,
+            network,
             blockchain,
             initial_sync_complete,
             shutdown,
@@ -591,7 +594,6 @@ impl OfferSyncService {
         self.offerbook
             .last_sync_ts
             .store(finished_at, Ordering::Relaxed);
-
         Ok(())
     }
 
@@ -600,9 +602,11 @@ impl OfferSyncService {
     /// worker pool and the manual `poll_one` path. Returns the recorded maker, or
     /// `None` if no entry exists for `addr` after the update (e.g. a concurrent
     /// `remove` raced the poll).
+    #[allow(clippy::too_many_arguments)]
     fn fetch_and_record_one(
         addr: MakerAddress,
         socks_port: u16,
+        network: Network,
         blockchain: &AnyBlockchain,
         offerbook: &Arc<RwLock<OfferBook>>,
         offerbook_path: &Path,
@@ -614,7 +618,7 @@ impl OfferSyncService {
         }
         let downloaded = addr
             .clone()
-            .download_offer_with_retries(socks_port, shutdown);
+            .download_offer_with_retries(socks_port, network, shutdown);
         // Verify before taking the guard. The backend calls in here can block on a
         // slow server, which would serialize every worker in the pool behind it.
         let outcome = downloaded.map(|oa| {
@@ -673,6 +677,7 @@ impl OfferSyncService {
         Self::fetch_and_record_one(
             address,
             self.socks_port,
+            self.network,
             &self.blockchain,
             &self.offerbook.inner,
             &self.offerbook.path,
@@ -696,6 +701,7 @@ impl OfferSyncService {
         let offerbook = self.offerbook.inner.clone();
         let offerbook_path = self.offerbook.path.clone();
         let socks_port = self.socks_port;
+        let network = self.network;
         let blockchain = self.blockchain.clone();
         let shutdown = self.shutdown.clone();
 
@@ -743,6 +749,7 @@ impl OfferSyncService {
                         let _ = Self::fetch_and_record_one(
                             addr,
                             socks_port,
+                        network,
                             &backend,
                             &offerbook,
                             &offerbook_path,
@@ -1128,13 +1135,14 @@ impl MakerAddress {
     fn download_offer_with_retries(
         self,
         socks_port: u16,
+        network: Network,
         shutdown: &AtomicBool,
     ) -> Option<OfferAndAddress> {
         for attempt in 1..=FIRST_CONNECT_ATTEMPTS {
             if shutdown.load(Ordering::Relaxed) {
                 return None;
             }
-            match self.clone().download_offer_auto(socks_port) {
+            match self.clone().download_offer_auto(socks_port, network) {
                 Ok(offer) => return Some(offer),
                 Err(e) if attempt < FIRST_CONNECT_ATTEMPTS => {
                     log::debug!(
@@ -1163,8 +1171,12 @@ impl MakerAddress {
         None
     }
 
-    fn download_offer_auto(self, socks_port: u16) -> Result<OfferAndAddress, TakerError> {
-        let (offer, protocol) = self.fetch_offer(socks_port)?;
+    fn download_offer_auto(
+        self,
+        socks_port: u16,
+        network: Network,
+    ) -> Result<OfferAndAddress, TakerError> {
+        let (offer, protocol) = self.fetch_offer(socks_port, network)?;
         Ok(OfferAndAddress {
             offer,
             address: self,
@@ -1174,17 +1186,21 @@ impl MakerAddress {
     }
 
     /// Download a single offer from a maker.
-    fn fetch_offer(&self, socks_port: u16) -> Result<(Offer, MakerProtocol), TakerError> {
+    fn fetch_offer(
+        &self,
+        socks_port: u16,
+        network: Network,
+    ) -> Result<(Offer, MakerProtocol), TakerError> {
         log::debug!("Downloading offer from maker: {}", self);
 
         #[cfg(feature = "integration-test")]
-        let mut socket = {
+        let socket = {
             let _ = socks_port;
             // Integration test: self.0 is "ip:port"
             TcpStream::connect(self.to_string())?
         };
         #[cfg(not(feature = "integration-test"))]
-        let mut socket = {
+        let socket = {
             use crate::protocol::common_messages::OPENSWAP_PORT;
 
             // Production: self.0 is a .onion hostname, connect via the Tor proxy
@@ -1200,13 +1216,14 @@ impl MakerAddress {
         socket.set_read_timeout(Some(Duration::from_secs(FIRST_CONNECT_ATTEMPT_TIMEOUT_SEC)))?;
         socket.set_write_timeout(Some(Duration::from_secs(FIRST_CONNECT_ATTEMPT_TIMEOUT_SEC)))?;
 
+        let mut stream = Bip324Stream::new(socket, network, bip324::Role::Initiator)?;
+
         // Send TakerHello
         let taker_hello = RouterTakerToMakerMessage::TakerHello(RouterTakerHello);
-        send_message(&mut socket, &taker_hello)?;
+        stream.send_message(&taker_hello)?;
 
         // Read MakerHello
-        let msg_bytes = read_message(&mut socket)?;
-        let msg: RouterMakerToTakerMessage = serde_cbor::from_slice(&msg_bytes)?;
+        let msg: RouterMakerToTakerMessage = stream.read_message()?;
 
         match msg {
             RouterMakerToTakerMessage::MakerHello(_hello) => {
@@ -1223,11 +1240,10 @@ impl MakerAddress {
 
         // Send GetOffer
         let get_offer = RouterTakerToMakerMessage::GetOffer(RouterGetOffer);
-        send_message(&mut socket, &get_offer)?;
+        stream.send_message(&get_offer)?;
 
         // Read Offer
-        let offer_bytes = read_message(&mut socket)?;
-        let offer_msg: RouterMakerToTakerMessage = serde_cbor::from_slice(&offer_bytes)?;
+        let offer_msg: RouterMakerToTakerMessage = stream.read_message()?;
 
         let router_offer = match offer_msg {
             RouterMakerToTakerMessage::Offer(offer) => *offer,

--- a/src/taker/taproot_swap.rs
+++ b/src/taker/taproot_swap.rs
@@ -14,7 +14,7 @@ use crate::{
         contract2::{create_hashlock_script, create_timelock_script},
         taproot_messages::{SerializableScalar, TaprootContractData},
     },
-    utill::{read_message, send_message, MIN_FEE_RATE},
+    utill::MIN_FEE_RATE,
     wallet::{
         swapcoin::{IncomingSwapCoin, OutgoingSwapCoin, WatchOnlySwapCoin},
         Wallet,
@@ -266,15 +266,14 @@ impl Taker {
                 ));
             }
 
-            send_message(
-                &mut stream,
-                &TakerToMakerMessage::TaprootContractData(Box::new(contract_data)),
-            )?;
+            stream.send_message(&TakerToMakerMessage::TaprootContractData(Box::new(
+                contract_data,
+            )))?;
             self.swap_state_mut()?.makers[i]
                 .taproot_exchange_mut()?
                 .contract_data_sent = true;
 
-            let msg_bytes = read_message(&mut stream)?;
+            let msg_bytes = stream.read_message()?;
             let msg: MakerToTakerMessage = serde_cbor::from_slice(&msg_bytes)?;
 
             match msg {

--- a/src/taker/taproot_swap.rs
+++ b/src/taker/taproot_swap.rs
@@ -14,7 +14,7 @@ use crate::{
         contract2::{create_hashlock_script, create_timelock_script},
         taproot_messages::{SerializableScalar, TaprootContractData},
     },
-    utill::{read_message, send_message, MIN_FEE_RATE},
+    utill::MIN_FEE_RATE,
     wallet::{
         swapcoin::{IncomingSwapCoin, OutgoingSwapCoin, WatchOnlySwapCoin},
         Blockchain, Wallet,
@@ -220,8 +220,7 @@ impl Taker {
         self.persist_swap(SwapPhase::FundsBroadcast)?;
         // funding_broadcast opens maker 0's connection before the
         // confirmation wait and keeps the whole route warm with keepalives,
-        // returning the live maker 0 stream for the contract exchange.
-        let maker0_stream = self.funding_broadcast()?;
+        self.funding_broadcast()?;
 
         // Phase 2: Exchange contract data with makers.
         log::info!("Exchanging contract data with makers...");
@@ -230,20 +229,9 @@ impl Taker {
         let hashlock_nonces = self.swap_state()?.hashlock_nonces.clone();
         let mut received_contracts: Vec<TaprootContractData> = Vec::new();
 
-        let mut maker0_stream = Some(maker0_stream);
-
         for i in 0..num_makers {
-            let maker_address = self.swap_state()?.makers[i].address.to_string();
-            let mut stream = if i == 0 {
-                // Reuse the warm, already-handshaked connection from funding_broadcast.
-                maker0_stream
-                    .take()
-                    .ok_or_else(|| TakerError::General("Missing warm maker 0 stream".to_string()))?
-            } else {
-                let mut stream = self.net_connect(&maker_address)?;
-                self.net_handshake(&mut stream)?;
-                stream
-            };
+            // tries to reuse the authenticated channel from earlier
+            let mut stream = self.take_connection(i)?;
             self.swap_state_mut()?.makers[i]
                 .taproot_exchange_mut()?
                 .connected = true;
@@ -360,16 +348,14 @@ impl Taker {
                 ));
             }
 
-            send_message(
-                &mut stream,
-                &TakerToMakerMessage::TaprootContractData(Box::new(contract_data)),
-            )?;
+            stream.send_message(&TakerToMakerMessage::TaprootContractData(Box::new(
+                contract_data,
+            )))?;
             self.swap_state_mut()?.makers[i]
                 .taproot_exchange_mut()?
                 .contract_data_sent = true;
 
-            let msg_bytes = read_message(&mut stream)?;
-            let msg: MakerToTakerMessage = serde_cbor::from_slice(&msg_bytes)?;
+            let msg: MakerToTakerMessage = stream.read_message()?;
 
             match msg {
                 MakerToTakerMessage::TaprootContractData(maker_contract) => {
@@ -537,6 +523,7 @@ impl Taker {
                     )));
                 }
             }
+            self.return_connection(i, stream)?;
         }
 
         // SP6-T: All makers responded, incoming/watchonly swapcoins created.
@@ -664,9 +651,8 @@ impl Taker {
     /// Broadcast contract transactions (Taproot) and wait for them to confirm.
     ///
     /// Opens maker 0's connection *before* the confirmation wait and keeps the
-    /// route alive with `WaitingFundingConfirmation` keepalives, returning the
-    /// live maker 0 stream so the contract exchange can reuse it.
-    fn funding_broadcast(&mut self) -> Result<std::net::TcpStream, TakerError> {
+    /// route alive with `WaitingFundingConfirmation` keepalives.
+    fn funding_broadcast(&mut self) -> Result<(), TakerError> {
         log::info!("Broadcasting contract transactions...");
 
         let wallet = self.write_wallet()?;
@@ -713,15 +699,15 @@ impl Taker {
         // Open and handshake maker 0 up front so its operational connection can
         // stay warm and be reused after the taker's funding confirms.
         let swap_id = self.swap_state()?.id.clone();
-        let maker0_address = self.swap_state()?.makers[0].address.to_string();
-        let mut stream = self.net_connect(&maker0_address)?;
-        self.net_handshake(&mut stream)?;
+        let stream = self.take_connection(0)?;
 
         self.wait_for_funding_confirmation(
             &contract_txids,
             required_confirms,
             crate::utill::TX_BROADCAST_TIMEOUT,
         )?;
+
+        self.return_connection(0, stream)?;
 
         #[cfg(debug_assertions)]
         log::debug!(
@@ -731,7 +717,7 @@ impl Taker {
             required_confirms
         );
         log::info!("Contract transactions broadcast and confirmed");
-        Ok(stream)
+        Ok(())
     }
 
     /// Wait for contract (funding) txs to reach `required_confirms`.

--- a/src/utill.rs
+++ b/src/utill.rs
@@ -156,6 +156,10 @@ pub fn estimate_funding_tx_fee_sats() -> u64 {
 /// of log verbosity.
 pub fn setup_taker_logger(filter: LevelFilter, is_stdout: bool, datadir: Option<PathBuf>) {
     LOGGER.get_or_init(|| {
+        let filter = std::env::var("RUST_LOG")
+            .ok()
+            .and_then(|v| v.parse().ok())
+            .unwrap_or(filter);
         // File logging is best-effort: without a data dir or a writable log
         // file we still want stdout logging, not a panic.
         let file_appender = match datadir.map(Ok).unwrap_or_else(get_taker_dir) {
@@ -217,6 +221,10 @@ pub fn setup_taker_logger(filter: LevelFilter, is_stdout: bool, datadir: Option<
 /// of log verbosity.
 pub fn setup_maker_logger(filter: LevelFilter, data_dir: Option<PathBuf>) {
     LOGGER.get_or_init(|| {
+        let filter = std::env::var("RUST_LOG")
+            .ok()
+            .and_then(|v| v.parse().ok())
+            .unwrap_or(filter);
         // File logging is best-effort: without a data dir or a writable log
         // file we still want stdout logging, not a panic.
         let file_appender = match data_dir.map(Ok).unwrap_or_else(get_maker_dir) {
@@ -1231,8 +1239,13 @@ mod tests {
         let listener = TcpListener::bind("127.0.0.1:0").unwrap();
         let address = listener.local_addr().unwrap();
 
+        let secp = Secp256k1::new();
+        let (sk, _) = secp.generate_keypair(&mut thread_rng());
+        let msg = bitcoin::secp256k1::Message::from_digest([0u8; 32]);
+        let session_id_sig = secp.sign_ecdsa_low_r(&msg, &sk);
         let message = MakerToTakerMessage::MakerHello(MakerHello {
             supported_protocols: vec![ProtocolVersion::Legacy, ProtocolVersion::Taproot],
+            session_id_sig,
         });
 
         thread::spawn(move || {


### PR DESCRIPTION
# Pull Request

## Description
- saves the corresponding session_id in ConnectionState
-  Replaced raw read_message() / send_message() helpers  with a Bip324Stream wrapper
- Identity binding is done when Maker sends taker AckSwap
  - Taker verifies:  tweakable_point matches the cached offer,  session_id matches the BIP324 transport layer, session_id_sig is valid against the tweakable point
- New Error types `Bip324Error`
 

## Related Issue(s)
Closes #801 <!-- replace with issue number if applicable -->
<!-- Add multiple lines if this PR closes multiple issues -->

## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code refactor / performance improvement
- [ ] Documentation update only
- [ ] CI / Docker / Build changes
- [ ] Other (please describe):

<!-- If breaking change, describe the migration path or config changes required: -->

## Protocol Version(s) Affected
- [ ] Legacy (ECDSA — `messages.rs`, `contract.rs`, `handlers.rs`)
- [ ] Taproot-Musig2 (`messages2.rs`, `contract2.rs`, `handlers2.rs`)
- [ ] Both
- [ ] Neither (infrastructure / tooling only)

> **Note:** When modifying protocol logic, changes must be made to **both** versions unless the
> scope is explicitly version-specific.

## Affected Component(s)
- [ ] **makerd** (background daemon)
- [ ] **taker** (CLI client)
- [ ] **maker-cli** (command-line tool)
- [ ] Core protocol / cryptography / library
- [ ] **watch_tower** (contract monitoring & recovery)
- [ ] Docker / deployment scripts
- [ ] Tests / test framework
- [ ] Documentation (`docs/`)
- [ ] Other (please specify):

## Checklist

### Code Quality
- [ ] I ran `cargo +nightly fmt --all` and committed the result
- [ ] I ran `cargo +stable clippy --all-features --lib --bins --tests -- -D warnings` with zero warnings
- [ ] I ran `cargo +stable clippy --examples -- -D warnings` with zero warnings
- [ ] I ran `RUSTDOCFLAGS="-D warnings" cargo +nightly doc --all-features --document-private-items --no-deps` with zero warnings
- [ ] Pre-commit git hook passes (`ln -s ../../git_hooks/pre-commit .git/hooks/pre-commit` if not already set)

### Testing
- [ ] All unit tests pass (`cargo test`)
- [ ] Integration tests pass (`cargo test --features integration-test`)
- [ ] Changes were manually tested on **regtest**
- [ ] End-to-end maker ↔ taker swap tested (where applicable)
- [ ] Test-only code is gated behind `#[cfg(feature = "integration-test")]`

### Documentation
- [ ] Relevant files in the `docs/` folder were updated
- [ ] Complex logic is commented

### Security & Privacy (Critical)
- [ ] This change preserves **trustlessness** and **atomic swap guarantees**
- [ ] No regression in **sybil resistance** or **fidelity bond** logic
- [ ] Tor anonymity and P2P message flow were reviewed
- [ ] No new attack vectors or trust assumptions introduced
- [ ] Edge cases and error handling considered
- [ ] ZMQ subscription integrity (raw tx/block feed) is unaffected
- [ ] `integration-test` feature flag is not reachable in production code paths

## How to Test
<!-- Step-by-step instructions so reviewers can verify quickly. -->

```bash
# Standard swap (good baseline)
cargo test --test standard_swap --features integration-test -- --nocapture

# Abort scenarios
cargo test --test abort1 --features integration-test -- --nocapture
cargo test --test taproot_taker_abort1 --features integration-test -- --nocapture

# Malicious behavior & recovery
cargo test --test malice1 --features integration-test -- --nocapture
cargo test --test taproot_timelock_recovery --features integration-test -- --nocapture

# Or run the full suite
cargo test --features integration-test
```

<!-- Add any additional manual steps specific to this PR
     (e.g. regtest node config, docker-setup, specific taker commands): -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Encrypts maker↔taker communication with BIP324 streams across swap, legacy, and offer synchronization flows.
  * Maker acknowledgement now includes a BIP324 session id plus signature; takers validate these during negotiation.
  * Offer synchronization now uses the configured Bitcoin network when establishing maker sessions.
* **Bug Fixes**
  * Improved handling and reporting of BIP324 protocol/connection-close failures for clearer network error behavior.
* **Chores**
  * Updated the pinned BIP324 dependency revision.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->