### PR TITLE
blocklist: add optional funding-source address screening

### DIFF
--- a/docs/blocklist.md
+++ b/docs/blocklist.md
@@ -1,0 +1,105 @@
+# Funding-Source Blocklist
+
+The blocklist allows a participant to refuse a swap when the counterparty's coins originate from a listed address.
+It applies to both the Legacy (v1) and Taproot (v2) protocols, and is disabled by default.
+
+## Matching
+
+Screening examines the transaction by which the counterparty pays into the swap.
+In Legacy that is its funding transaction; in Taproot, which has no separate funding transaction, it is the contract transaction that pays the taproot output.
+
+For each input of that transaction, the previous output it spends is looked up on-chain and its `scriptPubKey` is compared against the scripts derived from the listed addresses.
+A match refuses the swap.
+
+Only the previous outputs need to be on-chain, never the transaction being screened.
+In Legacy this lets the taker screen the maker's funding transaction while it is still unbroadcast, since the transaction reaches the taker in a protocol message.
+In Taproot the maker waits for the contract transaction to confirm before screening it, while the taker screens it on arrival — after the maker has broadcast it, but usually before it confirms.
+
+Two properties follow from this definition:
+
+- **Single hop.** Only the immediate inputs are examined. An address that received coins from a listed address is not itself matched. This is a direct-spend check, not a taint analysis.
+- **The output paid into the swap is not matched.** Each swap pays to an address derived from values exchanged during that swap — a 2-of-2 in Legacy, a taproot output in Taproot. It has not appeared on-chain before and will not appear again, so no list compiled in advance can contain it.
+
+## Screening points
+
+Each participant screens only the funding it directly receives.
+Intermediate maker-to-maker hops are not screened by the taker.
+
+```text
+Taker → Maker 1 → Maker 2 → Taker
+
+Maker 1 screens the Taker's funding
+Maker 2 screens Maker 1's funding
+Taker   screens Maker 2's funding
+```
+
+| Protocol | Role  | Screened at | Counterparty funded | Cost to refuse |
+|----------|-------|-------------|---------------------|----------------|
+| Legacy   | Maker | `ProofOfFunding`, before constructing its own funding | yes | reserved UTXOs released |
+| Legacy   | Taker | `ReqContractSigsAsRecvrAndSender` | not yet broadcast | timelock recovery |
+| Taproot  | Maker | contract data, after confirmation, before constructing its own funding | yes | reserved UTXOs released |
+| Taproot  | Taker | contract data returned by the final maker | yes | timelock recovery |
+
+A maker screens before broadcasting its own funding transaction, so refusal releases its reserved UTXOs and costs nothing further.
+A taker has already funded the swap when the counterparty's funding transaction becomes visible, so refusal means abandoning it and reclaiming its coins through timelock recovery.
+The taker always funds first, so this asymmetry follows from the protocol rather than from the blocklist.
+
+## Constraints
+
+| Condition | Behaviour |
+|-----------|-----------|
+| Input count above the configured maximum | Refused without screening |
+| Previous output cannot be resolved | Refused |
+| List empty | Returns without querying the node |
+| Entry's address encodes a different network | Skipped, with address and reason recorded |
+| All entries skipped | List behaves as empty |
+
+The input bound exists because each input costs one query against the participant's own node, and the transaction originates with the counterparty.
+
+Addresses encode their network, so a list compiled for one network loads as empty on another.
+The scripts are network-independent — the same key hash yields the same `scriptPubKey` across networks, and only the address encoding differs — so this is a property of the stored representation, not of the underlying data.
+
+## Storage
+
+A single JSON document, shared by both roles, held in the parent of each role's data directory so that a maker and a taker on one host consult the same file.
+
+```json
+{
+  "entries": [
+    { "address": "bc1qw508d6qejxtdg4y5r3zarvary0c5xw7kv8f3t4", "label": "Some Group" },
+    { "address": "1A1zP1eP5QGefi2DMPTfTL5SLmv7DivfNa", "label": null }
+  ]
+}
+```
+
+`label` is optional and is recorded in the refusal.
+
+Rules:
+
+- Entries are stored as address strings, but indexed and compared by the `scriptPubKey` each one derives to. Bech32 encoding is case-insensitive, so indexing by the string would admit two entries for one address.
+- A batch addition applies whole or not at all. If any address fails validation, none are written. An address encoding a different network fails validation like any malformed one, so it cannot be added. The skipping described under Constraints applies only on load, to entries already in the file.
+- Adding an address already present updates its label rather than appending.
+
+## Relationship to the protocol
+
+The blocklist is local policy and does not appear in any message.
+A peer cannot determine whether a counterparty applies one, and a refusal is indistinguishable from any other abandoned swap.
+This prevents peers from probing which addresses a participant considers unacceptable.
+
+Two participants may hold different lists, or none, without affecting the protocol.
+
+## Populating the list
+
+Addresses may be added individually or imported in bulk from a published dataset such as [OpenSanctions](https://www.opensanctions.org/), which publishes sanctioned crypto wallets.
+
+OpenSanctions data is [CC-BY-NC 4.0](https://creativecommons.org/licenses/by-nc/4.0/): personal and non-commercial use only.
+Their terms count compliance screening as commercial use even where it generates no revenue, so operating as a business requires a licence from them.
+The underlying sanctions lists can be consumed directly from their publishers instead. OpenSanctions aggregates hundreds of sources whose terms differ — some are public domain, others carry their own reuse conditions — so check each publisher's licence before relying on it.
+
+Selecting Bitcoin addresses requires either a Bitcoin chain tag or a `bc1` prefix:
+
+- Roughly 45% of wallet records carrying an address have no chain tag, so the tag alone is insufficient.
+- Other chains in the same data use Bitcoin's base58 form, so a record beginning `1` or `3` is not necessarily a Bitcoin address.
+
+An importer should therefore accept a record when its chain tag names Bitcoin, or when its address begins `bc1`, a prefix no other chain uses.
+The prefix test is case-insensitive: Bech32 addresses are also valid in all-uppercase form, so `BC1` must match as well.

--- a/src/atomic_file.rs
+++ b/src/atomic_file.rs
@@ -2,63 +2,47 @@
 
 use serde::{de::DeserializeOwned, Serialize};
 use std::{
-    fs::OpenOptions,
+    fs::{File, OpenOptions, TryLockError},
     io,
-    path::{Path, PathBuf},
-    time::{Duration, Instant},
+    path::Path,
 };
 
-const LOCK_TIMEOUT: Duration = Duration::from_secs(5);
-const LOCK_POLL_INTERVAL: Duration = Duration::from_millis(10);
-
+/// An exclusive lock on a file, held while this value is alive.
+///
+/// The lock belongs to the operating system, so it is released when this value
+/// is dropped and also if the process dies while holding it.
 pub(crate) struct FileLock {
-    path: PathBuf,
+    /// Holding the handle is the lock; closing it releases.
+    _file: File,
 }
 
 impl FileLock {
+    /// Block until the lock at `lock_path` is held.
+    ///
+    /// The sentinel file is created if absent and never removed: deleting it
+    /// would let another process lock a fresh inode under the same path while
+    /// this one still holds the old one.
     pub(crate) fn acquire(lock_path: &Path) -> io::Result<Self> {
         if let Some(parent) = lock_path.parent() {
             std::fs::create_dir_all(parent)?;
         }
 
-        let mut deadline = Instant::now() + LOCK_TIMEOUT;
+        let file = OpenOptions::new()
+            .write(true)
+            .create(true)
+            .truncate(false)
+            .open(lock_path)?;
 
-        loop {
-            match OpenOptions::new()
-                .write(true)
-                .create_new(true)
-                .open(lock_path)
-            {
-                Ok(_) => {
-                    return Ok(Self {
-                        path: lock_path.to_owned(),
-                    })
-                }
-                Err(error) if error.kind() == io::ErrorKind::AlreadyExists => {
-                    if Instant::now() > deadline {
-                        let is_stale = std::fs::metadata(lock_path)
-                            .and_then(|metadata| metadata.modified())
-                            .map(|modified| modified.elapsed().unwrap_or_default() > LOCK_TIMEOUT)
-                            .unwrap_or(true);
-
-                        if is_stale {
-                            std::fs::remove_file(lock_path)?;
-                        } else {
-                            deadline = Instant::now() + LOCK_TIMEOUT;
-                        }
-                    }
-
-                    std::thread::sleep(LOCK_POLL_INTERVAL);
-                }
-                Err(error) => return Err(error),
+        match file.try_lock() {
+            Ok(()) => {}
+            Err(TryLockError::WouldBlock) => {
+                log::info!("Waiting for lock on {}", lock_path.display());
+                file.lock()?;
             }
+            Err(TryLockError::Error(error)) => return Err(error),
         }
-    }
-}
 
-impl Drop for FileLock {
-    fn drop(&mut self) {
-        let _ = std::fs::remove_file(&self.path);
+        Ok(Self { _file: file })
     }
 }
 

--- a/src/atomic_file.rs
+++ b/src/atomic_file.rs
@@ -1,0 +1,87 @@
+//! Shared file-locking and atomic JSON-writing helpers.
+
+use serde::{de::DeserializeOwned, Serialize};
+use std::{
+    fs::OpenOptions,
+    io,
+    path::{Path, PathBuf},
+    time::{Duration, Instant},
+};
+
+const LOCK_TIMEOUT: Duration = Duration::from_secs(5);
+const LOCK_POLL_INTERVAL: Duration = Duration::from_millis(10);
+
+pub(crate) struct FileLock {
+    path: PathBuf,
+}
+
+impl FileLock {
+    pub(crate) fn acquire(lock_path: &Path) -> io::Result<Self> {
+        if let Some(parent) = lock_path.parent() {
+            std::fs::create_dir_all(parent)?;
+        }
+
+        let mut deadline = Instant::now() + LOCK_TIMEOUT;
+
+        loop {
+            match OpenOptions::new()
+                .write(true)
+                .create_new(true)
+                .open(lock_path)
+            {
+                Ok(_) => {
+                    return Ok(Self {
+                        path: lock_path.to_owned(),
+                    })
+                }
+                Err(error) if error.kind() == io::ErrorKind::AlreadyExists => {
+                    if Instant::now() > deadline {
+                        let is_stale = std::fs::metadata(lock_path)
+                            .and_then(|metadata| metadata.modified())
+                            .map(|modified| modified.elapsed().unwrap_or_default() > LOCK_TIMEOUT)
+                            .unwrap_or(true);
+
+                        if is_stale {
+                            std::fs::remove_file(lock_path)?;
+                        } else {
+                            deadline = Instant::now() + LOCK_TIMEOUT;
+                        }
+                    }
+
+                    std::thread::sleep(LOCK_POLL_INTERVAL);
+                }
+                Err(error) => return Err(error),
+            }
+        }
+    }
+}
+
+impl Drop for FileLock {
+    fn drop(&mut self) {
+        let _ = std::fs::remove_file(&self.path);
+    }
+}
+
+pub(crate) fn read_json<T: DeserializeOwned + Default>(path: &Path) -> io::Result<T> {
+    if !path.exists() {
+        return Ok(T::default());
+    }
+
+    let content = std::fs::read_to_string(path)?;
+    serde_json::from_str(&content).map_err(io::Error::other)
+}
+
+pub(crate) fn write_json_atomically<T: Serialize>(path: &Path, value: &T) -> io::Result<()> {
+    let json = serde_json::to_string_pretty(value).map_err(io::Error::other)?;
+    let temporary_path = path.with_extension("partial");
+
+    {
+        use io::Write;
+
+        let mut temporary_file = std::fs::File::create(&temporary_path)?;
+        temporary_file.write_all(json.as_bytes())?;
+        temporary_file.sync_all()?;
+    }
+
+    std::fs::rename(&temporary_path, path)
+}

--- a/src/bin/maker-cli.rs
+++ b/src/bin/maker-cli.rs
@@ -2,6 +2,7 @@ use std::{fs, net::TcpStream, path::PathBuf, time::Duration};
 
 use clap::Parser;
 use openswap::{
+    blocklist::BlocklistEntry,
     maker::{AuthenticatedRpcRequest, MakerError, RpcMsgReq, RpcMsgResp},
     utill::{get_maker_dir, read_message, send_message, MIN_FEE_RATE},
 };
@@ -77,6 +78,19 @@ enum Commands {
         #[arg(long, short = 's')]
         swap_id: String,
     },
+    /// Add or update an address in the funding-source blocklist.
+    BlocklistAdd {
+        /// Bitcoin address to block.
+        address: String,
+        /// Optional note explaining why the address is blocked.
+        #[arg(long, short = 'l')]
+        label: Option<String>,
+    },
+    /// Remove an address from the funding-source blocklist.
+    BlocklistRemove {
+        /// Bitcoin address to remove.
+        address: String,
+    },
 }
 
 fn main() -> Result<(), MakerError> {
@@ -148,6 +162,24 @@ fn main() -> Result<(), MakerError> {
                 stream,
                 &rpc_cookie,
                 RpcMsgReq::VerifyDeniability { swap_id },
+            )?;
+        }
+        Commands::BlocklistAdd { address, label } => {
+            send_rpc_req(
+                stream,
+                &rpc_cookie,
+                RpcMsgReq::BlocklistAdd {
+                    entries: vec![BlocklistEntry::new(address, label)],
+                },
+            )?;
+        }
+        Commands::BlocklistRemove { address } => {
+            send_rpc_req(
+                stream,
+                &rpc_cookie,
+                RpcMsgReq::BlocklistRemove {
+                    addresses: vec![address],
+                },
             )?;
         }
     }

--- a/src/bin/taker.rs
+++ b/src/bin/taker.rs
@@ -140,6 +140,19 @@ enum Commands {
         #[clap(long, short = 'm')]
         address: String,
     },
+    /// Add or update an address in the funding-source blocklist.
+    BlocklistAdd {
+        /// Bitcoin address to block.
+        address: String,
+        /// Optional note explaining why the address is blocked.
+        #[clap(long, short = 'l')]
+        label: Option<String>,
+    },
+    /// Remove an address from the funding-source blocklist.
+    BlocklistRemove {
+        /// Bitcoin address to remove.
+        address: String,
+    },
     /// Initiate the openswap process
     OpenSwap {
         /// Sets the Maker count to swap with. Swapping with less than 2 makers is not allowed to maintain client privacy.
@@ -375,6 +388,7 @@ fn main() -> Result<(), TakerError> {
     let config = TakerInitConfig {
         data_dir: Some(data_dir),
         socks_port: file_config.socks_port,
+        check_blocklist: Some(file_config.check_blocklist),
         control_port: Some(file_config.control_port),
         tor_auth_password: args.tor_auth.clone().or_else(|| {
             (!file_config.tor_auth_password.is_empty()).then_some(file_config.tor_auth_password)
@@ -539,6 +553,14 @@ fn main() -> Result<(), TakerError> {
             } else {
                 println!("No maker with address {address} in offerbook");
             }
+        }
+        Commands::BlocklistAdd { address, label } => {
+            let outcome = taker.add_blocklist_entry(address.clone(), label.clone())?;
+            println!("Added: {}, updated: {}", outcome.added, outcome.updated);
+        }
+        Commands::BlocklistRemove { address } => {
+            let removed = taker.remove_blocklist_entry(address.clone())?;
+            println!("Removed: {removed}");
         }
         Commands::OpenSwap {
             makers,

--- a/src/bin/taker.rs
+++ b/src/bin/taker.rs
@@ -414,10 +414,16 @@ fn main() -> Result<(), TakerError> {
         })?;
     }
 
-    // Sync wallet after initialization
-    lock_debug!(taker.get_wallet().write())
-        .unwrap()
-        .sync_and_save(&openswap::utill::NO_SHUTDOWN)?;
+    // Sync wallet after initialization. Blocklist edits only touch the local
+    // JSON file, so they skip the chain sync.
+    if !matches!(
+        args.command,
+        Commands::BlocklistAdd { .. } | Commands::BlocklistRemove { .. }
+    ) {
+        lock_debug!(taker.get_wallet().write())
+            .unwrap()
+            .sync_and_save(&openswap::utill::NO_SHUTDOWN)?;
+    }
 
     match &args.command {
         Commands::ListUtxo => {

--- a/src/blocklist.rs
+++ b/src/blocklist.rs
@@ -18,6 +18,11 @@ use std::{
 
 const BLOCKLIST_FILE: &str = "blocklist.json";
 
+/// Maximum number of funding inputs screened per transaction.
+/// Each input's previous output is fetched from the node, so an unbounded
+/// count on a counterparty-supplied transaction can take arbitrarily long.
+const MAX_FUNDING_INPUTS: usize = 25;
+
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 /// A Bitcoin address to reject as a funding source.
 pub struct BlocklistEntry {
@@ -137,8 +142,24 @@ pub fn screen_funding_tx(
     let blocklist = AddressBlocklist::load(data_dir, network)?;
 
     if blocklist.is_empty() {
-        log::info!("No blocklist entries usable on {network}, skipping funding screen");
+        if blocklist.path().exists() {
+            log::warn!(
+                "Blocklist {} holds no entries usable on {network}, skipping funding screen",
+                blocklist.path().display()
+            );
+        } else {
+            log::debug!("No blocklist file, skipping funding screen");
+        }
         return Ok(());
+    }
+
+    if tx.input.len() > MAX_FUNDING_INPUTS {
+        return Err(BlocklistError::InputResolution(WalletError::General(
+            format!(
+                "funding transaction has {} inputs, limit is {MAX_FUNDING_INPUTS}",
+                tx.input.len()
+            ),
+        )));
     }
 
     for (outpoint, script) in wallet.resolve_input_scripts(tx)? {

--- a/src/blocklist.rs
+++ b/src/blocklist.rs
@@ -1,0 +1,468 @@
+//! Persistent funding-source address blocklist.
+//!
+//! Funding transactions are screened by resolving each input's previous output
+//! and comparing its script pubkey with the scripts derived from listed addresses.
+
+use crate::{
+    atomic_file::{read_json, write_json_atomically, FileLock},
+    utill::parse_checked_address,
+    wallet::{Wallet, WalletError},
+};
+use bitcoin::{Network, OutPoint, Script, ScriptBuf, Transaction};
+use serde::{Deserialize, Serialize};
+use std::{
+    collections::HashMap,
+    fmt, io,
+    path::{Path, PathBuf},
+};
+
+const BLOCKLIST_FILE: &str = "blocklist.json";
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+/// A Bitcoin address to reject as a funding source.
+pub struct BlocklistEntry {
+    /// Address string supplied when the entry was added.
+    pub address: String,
+    /// Optional note describing why the address is blocked.
+    #[serde(default)]
+    pub label: Option<String>,
+}
+
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+/// Counts produced by an add operation.
+pub struct AddOutcome {
+    /// Number of addresses that were not previously present.
+    pub added: usize,
+    /// Number of existing addresses whose entries were replaced.
+    pub updated: usize,
+}
+
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+struct BlocklistFile {
+    #[serde(default)]
+    entries: Vec<BlocklistEntry>,
+}
+
+/// Errors produced while storing or applying the funding-source blocklist.
+#[derive(Debug)]
+pub enum BlocklistError {
+    /// Reading, locking, or writing the blocklist file failed.
+    IO(io::Error),
+    /// One or more supplied addresses were malformed or for the wrong network.
+    ///
+    /// Each tuple contains the rejected address and its validation error.
+    InvalidAddresses(Vec<(String, String)>),
+    /// A funding transaction input's previous output could not be resolved.
+    InputResolution(WalletError),
+    /// A funding input spends an output associated with a listed address.
+    BlockedAddress {
+        /// Previous output spent by the rejected funding input.
+        outpoint: OutPoint,
+        /// Blocklist entry matching that previous output's script pubkey.
+        entry: BlocklistEntry,
+    },
+}
+
+impl fmt::Display for BlocklistError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::IO(error) => write!(f, "blocklist file error: {error}"),
+            Self::InvalidAddresses(rejected) => {
+                write!(f, "{} address rejected, nothing written", rejected.len())?;
+
+                for (address, reason) in rejected {
+                    write!(f, "\n {address} - {reason}")?;
+                }
+
+                Ok(())
+            }
+            Self::InputResolution(error) => {
+                write!(f, "could not resolve funding transaction inputs: {error}")
+            }
+            Self::BlockedAddress { outpoint, entry } => {
+                write!(
+                    f,
+                    "funding input {outpoint} uses blocked address {}",
+                    entry.address
+                )?;
+                if let Some(label) = &entry.label {
+                    write!(f, " ({label})")?;
+                }
+                Ok(())
+            }
+        }
+    }
+}
+
+impl std::error::Error for BlocklistError {}
+
+impl From<io::Error> for BlocklistError {
+    fn from(error: io::Error) -> Self {
+        Self::IO(error)
+    }
+}
+
+impl From<WalletError> for BlocklistError {
+    fn from(error: WalletError) -> Self {
+        Self::InputResolution(error)
+    }
+}
+
+impl BlocklistEntry {
+    /// Construct an address entry with an optional explanatory label.
+    pub fn new(address: String, label: Option<String>) -> Self {
+        Self { address, label }
+    }
+}
+
+/// Resolve the shared blocklist path from a maker or taker data directory.
+///
+/// The file is placed in the data directory's parent so sibling maker and
+/// taker directories use the same `blocklist.json` file.
+pub fn blocklist_path(data_dir: &Path) -> PathBuf {
+    data_dir.parent().unwrap_or(data_dir).join(BLOCKLIST_FILE)
+}
+
+/// Reject a funding transaction when any input comes from a listed address.
+///
+/// The current blocklist file is loaded for every call. If it is empty, this
+/// returns without querying the blockchain backend. Otherwise, every input's
+/// previous-output script is resolved through the wallet and checked.
+pub fn screen_funding_tx(
+    data_dir: &Path,
+    network: Network,
+    wallet: &Wallet,
+    tx: &Transaction,
+) -> Result<(), BlocklistError> {
+    let blocklist = AddressBlocklist::load(data_dir, network)?;
+
+    if blocklist.is_empty() {
+        log::info!("No blocklist entries usable on {network}, skipping funding screen");
+        return Ok(());
+    }
+
+    for (outpoint, script) in wallet.resolve_input_scripts(tx)? {
+        if let Some(entry) = blocklist.matching(script.as_script()) {
+            log::warn!(
+                "Funding input {outpoint} uses blocked address {} (label: {:?})",
+                entry.address,
+                entry.label
+            );
+            return Err(BlocklistError::BlockedAddress {
+                outpoint,
+                entry: entry.clone(),
+            });
+        }
+    }
+
+    Ok(())
+}
+
+/// Index entries by script pubkey, skipping any that do not parse.
+fn index_entries(
+    entries: Vec<BlocklistEntry>,
+    network: Network,
+) -> HashMap<ScriptBuf, BlocklistEntry> {
+    let mut indexed = HashMap::with_capacity(entries.len());
+
+    for entry in entries {
+        match parse_checked_address(&entry.address, network) {
+            Ok(address) => {
+                if indexed
+                    .insert(address.script_pubkey(), entry.clone())
+                    .is_some()
+                {
+                    log::warn!(
+                        "Blocklist lists {} more than once, keeping the last entry",
+                        entry.address
+                    );
+                }
+            }
+            Err(error) => {
+                log::warn!(
+                    "Skipping unusable blocklist entry {}: {error}",
+                    entry.address
+                );
+            }
+        }
+    }
+    indexed
+}
+
+/// In-memory script index backed by a shared JSON file.
+pub struct AddressBlocklist {
+    inner: HashMap<ScriptBuf, BlocklistEntry>,
+    path: PathBuf,
+    network: Network,
+}
+
+impl AddressBlocklist {
+    /// Load the blocklist associated with `data_dir` for `network`.
+    ///
+    /// A missing file produces an empty blocklist. An unreadable or malformed
+    /// file returns an error so enabled funding screening fails closed. Entries
+    /// that cannot be parsed are skipped.
+    pub fn load(data_dir: &Path, network: Network) -> Result<Self, BlocklistError> {
+        let path = blocklist_path(data_dir);
+        let file = read_json::<BlocklistFile>(&path)?;
+
+        Ok(Self {
+            inner: index_entries(file.entries, network),
+            path,
+            network,
+        })
+    }
+
+    fn validate_all<'a>(
+        &self,
+        addresses: impl Iterator<Item = &'a str>,
+    ) -> Result<Vec<ScriptBuf>, BlocklistError> {
+        let mut scripts = Vec::new();
+        let mut rejected = Vec::new();
+
+        for address in addresses {
+            match parse_checked_address(address, self.network) {
+                Ok(parsed) => scripts.push(parsed.script_pubkey()),
+                Err(error) => rejected.push((address.to_string(), error.to_string())),
+            }
+        }
+
+        if rejected.is_empty() {
+            Ok(scripts)
+        } else {
+            Err(BlocklistError::InvalidAddresses(rejected))
+        }
+    }
+
+    fn read_current(&self) -> Result<HashMap<ScriptBuf, BlocklistEntry>, BlocklistError> {
+        let file: BlocklistFile = read_json(&self.path)?;
+        Ok(index_entries(file.entries, self.network))
+    }
+
+    fn commit(
+        &mut self,
+        _lock: &FileLock,
+        entries: HashMap<ScriptBuf, BlocklistEntry>,
+    ) -> Result<(), BlocklistError> {
+        let file = BlocklistFile {
+            entries: entries.values().cloned().collect(),
+        };
+
+        write_json_atomically(&self.path, &file)?;
+        self.inner = entries;
+        Ok(())
+    }
+
+    /// Atomically add new entries or replace existing entries for the same scripts.
+    ///
+    /// All addresses are validated before the file is changed. The persisted
+    /// file is re-read while holding its cross-process lock so another process's
+    /// completed changes are preserved.
+    pub fn add(&mut self, entries: Vec<BlocklistEntry>) -> Result<AddOutcome, BlocklistError> {
+        let scripts = self.validate_all(entries.iter().map(|entry| entry.address.as_str()))?;
+
+        let lock_path = self.path.with_extension("lock");
+        let lock = FileLock::acquire(&lock_path)?;
+        let mut current = self.read_current()?;
+        let mut outcome = AddOutcome::default();
+
+        for (entry, script) in entries.into_iter().zip(scripts) {
+            match current.insert(script, entry) {
+                Some(_) => outcome.updated += 1,
+                None => outcome.added += 1,
+            }
+        }
+        self.commit(&lock, current)?;
+        Ok(outcome)
+    }
+
+    /// Atomically remove addresses and return the number of entries removed.
+    ///
+    /// All addresses are validated before the file is changed. Addresses not
+    /// currently present do not contribute to the returned count.
+    pub fn remove(&mut self, addresses: Vec<String>) -> Result<usize, BlocklistError> {
+        let scripts = self.validate_all(addresses.iter().map(String::as_str))?;
+
+        let lock_path = self.path.with_extension("lock");
+        let lock = FileLock::acquire(&lock_path)?;
+        let mut current = self.read_current()?;
+
+        let removed = scripts
+            .into_iter()
+            .filter(|script| current.remove(script).is_some())
+            .count();
+
+        self.commit(&lock, current)?;
+        Ok(removed)
+    }
+
+    /// Return the blocklist entry matching `script`, if one exists.
+    pub fn matching(&self, script: &Script) -> Option<&BlocklistEntry> {
+        self.inner.get(script)
+    }
+
+    /// Return whether the in-memory script index contains no entries.
+    pub fn is_empty(&self) -> bool {
+        self.inner.is_empty()
+    }
+
+    /// Return the path of the JSON file backing this blocklist.
+    pub fn path(&self) -> &Path {
+        &self.path
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use bitcoin::{
+        key::Keypair,
+        secp256k1::{Secp256k1, SecretKey},
+        Address,
+    };
+    use bitcoind::tempfile::tempdir;
+
+    use super::*;
+
+    fn test_address(secret_byte: u8, network: Network) -> Address {
+        let secp = Secp256k1::new();
+        let secret = SecretKey::from_slice(&[secret_byte; 32]).unwrap();
+        let keypair = Keypair::from_secret_key(&secp, &secret);
+        Address::p2tr(&secp, keypair.x_only_public_key().0, None, network)
+    }
+
+    #[test]
+    fn add_update_remove_round_trip() {
+        let temp = tempdir().unwrap();
+        let data_dir = temp.path().join("maker");
+        let address = test_address(1, Network::Regtest);
+        let script = address.script_pubkey();
+        let address = address.to_string();
+
+        let mut blocklist = AddressBlocklist::load(&data_dir, Network::Regtest).unwrap();
+        assert!(blocklist.is_empty());
+        assert_eq!(
+            blocklist
+                .add(vec![BlocklistEntry::new(
+                    address.clone(),
+                    Some("first label".to_string()),
+                )])
+                .unwrap(),
+            AddOutcome {
+                added: 1,
+                updated: 0,
+            }
+        );
+        assert_eq!(
+            blocklist
+                .add(vec![BlocklistEntry::new(
+                    address.clone(),
+                    Some("updated label".to_string()),
+                )])
+                .unwrap(),
+            AddOutcome {
+                added: 0,
+                updated: 1,
+            }
+        );
+
+        let mut reloaded = AddressBlocklist::load(&data_dir, Network::Regtest).unwrap();
+        assert_eq!(
+            reloaded.matching(script.as_script()),
+            Some(&BlocklistEntry::new(
+                address.clone(),
+                Some("updated label".to_string()),
+            ))
+        );
+
+        assert_eq!(
+            reloaded
+                .remove(vec![test_address(2, Network::Regtest).to_string()])
+                .unwrap(),
+            0
+        );
+        assert_eq!(reloaded.remove(vec![address]).unwrap(), 1);
+        assert!(AddressBlocklist::load(&data_dir, Network::Regtest)
+            .unwrap()
+            .is_empty());
+    }
+
+    #[test]
+    fn add_rejects_all_entries_when_any_address_is_invalid() {
+        let temp = tempdir().unwrap();
+        let data_dir = temp.path().join("taker");
+        let mut blocklist = AddressBlocklist::load(&data_dir, Network::Regtest).unwrap();
+        let valid = test_address(3, Network::Regtest).to_string();
+        let wrong_network = test_address(4, Network::Bitcoin).to_string();
+
+        let error = blocklist
+            .add(vec![
+                BlocklistEntry::new(valid, None),
+                BlocklistEntry::new("not-an-address".to_string(), None),
+                BlocklistEntry::new(wrong_network, None),
+            ])
+            .unwrap_err();
+
+        match error {
+            BlocklistError::InvalidAddresses(rejected) => assert_eq!(rejected.len(), 2),
+            other => panic!("unexpected error: {}", other),
+        }
+        assert!(AddressBlocklist::load(&data_dir, Network::Regtest)
+            .unwrap()
+            .is_empty());
+    }
+
+    #[test]
+    fn concurrent_adds_preserve_every_entry() {
+        let temp = tempdir().unwrap();
+        let data_dir = temp.path().join("maker");
+        let addresses: Vec<_> = (10..18)
+            .map(|secret_byte| test_address(secret_byte, Network::Regtest))
+            .collect();
+
+        let handles: Vec<_> = addresses
+            .iter()
+            .map(ToString::to_string)
+            .map(|address| {
+                let data_dir = data_dir.clone();
+                std::thread::spawn(move || {
+                    AddressBlocklist::load(&data_dir, Network::Regtest)
+                        .unwrap()
+                        .add(vec![BlocklistEntry::new(address, None)])
+                        .unwrap()
+                })
+            })
+            .collect();
+
+        for handle in handles {
+            assert_eq!(
+                handle.join().unwrap(),
+                AddOutcome {
+                    added: 1,
+                    updated: 0,
+                }
+            );
+        }
+
+        let reloaded = AddressBlocklist::load(&data_dir, Network::Regtest).unwrap();
+        for address in addresses {
+            assert_eq!(
+                reloaded.matching(address.script_pubkey().as_script()),
+                Some(&BlocklistEntry::new(address.to_string(), None))
+            );
+        }
+    }
+
+    #[test]
+    fn malformed_file_returns_error_instead_of_empty_blocklist() {
+        let temp = tempdir().unwrap();
+        let data_dir = temp.path().join("maker");
+        let path = blocklist_path(&data_dir);
+        std::fs::write(&path, "{not valid json").unwrap();
+
+        match AddressBlocklist::load(&data_dir, Network::Regtest) {
+            Err(BlocklistError::IO(_)) => {}
+            Err(other) => panic!("unexpected error: {}", other),
+            Ok(_) => panic!("malformed blocklist must not be treated as empty"),
+        }
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,6 +3,8 @@
 pub extern crate bitcoin;
 pub extern crate bitcoind;
 
+pub(crate) mod atomic_file;
+pub mod blocklist;
 pub mod error;
 pub mod fee_estimation;
 pub mod maker;

--- a/src/maker/api.rs
+++ b/src/maker/api.rs
@@ -17,6 +17,7 @@ use std::{
 use bitcoin::{bip32::ChainCode, Amount, Network, OutPoint, PublicKey, Transaction};
 
 use crate::{
+    blocklist::AddressBlocklist,
     lock_debug,
     maker::nostr::NOSTR_RELAYS,
     protocol::common_messages::{FidelityProof, ProtocolVersion, SwapDetails},
@@ -129,6 +130,8 @@ pub struct MakerServerConfig {
     pub min_swap_amount: u64,
     /// Required confirmations for funding transactions.
     pub required_confirms: u32,
+    /// Whether funding inputs should be checked against the address blocklist.
+    pub check_blocklist: bool,
     /// Supported protocol versions.
     pub supported_protocols: Vec<ProtocolVersion>,
     /// Fidelity bond amount in satoshis.
@@ -168,6 +171,7 @@ impl Default for MakerServerConfig {
             time_relative_fee_pct: 0.0001,
             min_swap_amount: 10_000,
             required_confirms: 1,
+            check_blocklist: false,
             supported_protocols: vec![ProtocolVersion::Legacy, ProtocolVersion::Taproot],
             fidelity_amount: 10_000,   // 0.0001 BTC
             fidelity_timelock: 15_000, // ~6 months (MAX_FIDELITY_TIMELOCK)
@@ -276,6 +280,10 @@ impl MakerServerConfig {
                 config_map.get("required_confirms"),
                 default_config.required_confirms,
             ),
+            check_blocklist: parse_field(
+                config_map.get("check_blocklist"),
+                default_config.check_blocklist,
+            ),
             fidelity_amount: parse_field(
                 config_map.get("fidelity_amount"),
                 default_config.fidelity_amount,
@@ -338,6 +346,8 @@ amount_relative_fee_pct = {}
 time_relative_fee_pct = {}
 # Required confirmations for funding transactions
 required_confirms = {}
+# Check funding inputs against the address blocklist
+check_blocklist = {}
 ",
             self.network_port,
             self.rpc_port,
@@ -355,6 +365,7 @@ required_confirms = {}
             self.amount_relative_fee_pct,
             self.time_relative_fee_pct,
             self.required_confirms,
+            self.check_blocklist,
         );
 
         std::fs::create_dir_all(path.parent().ok_or_else(|| {
@@ -596,7 +607,10 @@ impl MakerServer {
             );
             config.network = wallet_network;
         }
-
+        // Validate the blocklist on startup when screening is enabled.
+        if config.check_blocklist {
+            AddressBlocklist::load(&data_dir, config.network)?;
+        }
         // Initialize watch service. A failure here aborts init instead of
         // entering recovery-only: that mode polls the same backend that
         // just failed to build, so there is nothing to degrade to.
@@ -1350,6 +1364,17 @@ impl MakerTrait for MakerServer {
             .map_err(|_| MakerError::General("Failed to lock wallet"))?;
 
         wallet.send_tx(tx).map_err(MakerError::Wallet)
+    }
+
+    fn screen_funding_tx(&self, tx: &Transaction) -> Result<(), MakerError> {
+        if !self.config.check_blocklist {
+            return Ok(());
+        }
+
+        let wallet = lock_debug!(self.wallet.read())
+            .map_err(|_| MakerError::General("Failed to lock wallet"))?;
+        crate::blocklist::screen_funding_tx(&self.data_dir, self.config.network, &wallet, tx)
+            .map_err(MakerError::Blocklist)
     }
 
     fn is_transaction_known(&self, txid: &bitcoin::Txid) -> bool {

--- a/src/maker/error.rs
+++ b/src/maker/error.rs
@@ -5,8 +5,8 @@ use std::sync::{MutexGuard, PoisonError, RwLockReadGuard, RwLockWriteGuard};
 use bitcoin::{secp256k1, Amount};
 
 use crate::{
-    error::NetError, protocol::error::ProtocolError, utill::TorError, wallet::WalletError,
-    watch_tower::watcher_error::WatcherError,
+    blocklist::BlocklistError, error::NetError, protocol::error::ProtocolError, utill::TorError,
+    wallet::WalletError, watch_tower::watcher_error::WatcherError,
 };
 
 #[cfg(feature = "integration-test")]
@@ -49,6 +49,8 @@ pub enum MakerError {
     Secp(secp256k1::Error),
     /// Represents an error related to wallet operations.
     Wallet(WalletError),
+    /// Represents a funding-input blocklist error.
+    Blocklist(BlocklistError),
     /// Represents a network-related error.
     Net(NetError),
     /// Represents an error triggered by special maker behavior.
@@ -113,6 +115,12 @@ impl From<ProtocolError> for MakerError {
 impl From<WalletError> for MakerError {
     fn from(value: WalletError) -> Self {
         Self::Wallet(value)
+    }
+}
+
+impl From<BlocklistError> for MakerError {
+    fn from(value: BlocklistError) -> Self {
+        Self::Blocklist(value)
     }
 }
 

--- a/src/maker/handlers.rs
+++ b/src/maker/handlers.rs
@@ -281,6 +281,9 @@ pub trait Maker: Send + Sync {
     /// Broadcast a transaction.
     fn broadcast_transaction(&self, tx: &Transaction) -> Result<bitcoin::Txid, MakerError>;
 
+    /// Check every funding input's previous-output script against the blocklist.
+    fn screen_funding_tx(&self, tx: &Transaction) -> Result<(), MakerError>;
+
     /// Whether the backend already knows this transaction (mempool or chain);
     /// used to tolerate duplicate-broadcast errors. `false` also covers
     /// "backend down". Core must run with `-txindex=1`.

--- a/src/maker/legacy_handlers.rs
+++ b/src/maker/legacy_handlers.rs
@@ -217,6 +217,11 @@ fn process_proof_of_funding<M: Maker>(
     }
 
     let hashvalue = maker.verify_proof_of_funding(&pof)?;
+
+    for funding_info in &pof.confirmed_funding_txes {
+        maker.screen_funding_tx(&funding_info.funding_tx)?;
+    }
+
     #[cfg(debug_assertions)]
     log::debug!(
         "[CONTRACT_STATE] Role: Maker | Protocol: Legacy | SwapID: {} | ProofFundingTxs: {} | NextHopKeys: {} | RefundLocktime: {} | Status: verified",

--- a/src/maker/rpc/messages.rs
+++ b/src/maker/rpc/messages.rs
@@ -1,6 +1,9 @@
 use std::fmt::Display;
 
-use crate::utill::UTXO;
+use crate::{
+    blocklist::{AddOutcome, BlocklistEntry},
+    utill::UTXO,
+};
 use bitcoin::Txid;
 use serde::{Deserialize, Serialize};
 use serde_json::{json, to_string_pretty};
@@ -61,6 +64,16 @@ pub enum RpcMsgReq {
         /// The swap ID to verify.
         swap_id: String,
     },
+    /// Add or update blocklist entries.
+    BlocklistAdd {
+        /// Address entries to add or update.
+        entries: Vec<BlocklistEntry>,
+    },
+    /// Remove addresses from the blocklist.
+    BlocklistRemove {
+        /// Addresses to remove.
+        addresses: Vec<String>,
+    },
 }
 
 /// Enum representing RPC message responses.
@@ -111,6 +124,10 @@ pub enum RpcMsgResp {
     ListBonds(String),
     /// Response to a verify-deniability request.
     VerifyDeniabilityResp(bool),
+    /// Response containing the number of added and updated blocklist entries.
+    BlocklistAddResp(AddOutcome),
+    /// Response containing the number of removed blocklist entries.
+    BlocklistRemoveResp(usize),
 }
 
 impl Display for RpcMsgResp {
@@ -156,6 +173,10 @@ impl Display for RpcMsgResp {
                     write!(f, "Proof invalid or not found for this swap ID")
                 }
             }
+            Self::BlocklistAddResp(outcome) => {
+                write!(f, "Added: {}, updated: {}", outcome.added, outcome.updated)
+            }
+            Self::BlocklistRemoveResp(removed) => write!(f, "Removed: {removed}"),
         }
     }
 }

--- a/src/maker/rpc/server.rs
+++ b/src/maker/rpc/server.rs
@@ -16,6 +16,7 @@ use super::messages::{AuthenticatedRpcRequest, RpcMsgReq};
 #[cfg(not(feature = "integration-test"))]
 use crate::utill::TorError;
 use crate::{
+    blocklist::AddressBlocklist,
     lock_debug,
     maker::{
         api::{MakerServerConfig, ShutdownSignal},
@@ -210,6 +211,22 @@ fn handle_request<M: MakerRpc>(
             match lock_debug!(maker.wallet().read())?.verify_deniability(&swap_id) {
                 Ok(valid) => RpcMsgResp::VerifyDeniabilityResp(valid),
                 Err(e) => RpcMsgResp::ServerError(e.to_string()),
+            }
+        }
+        RpcMsgReq::BlocklistAdd { entries } => {
+            match AddressBlocklist::load(maker.data_dir(), maker.config().network)
+                .and_then(|mut blocklist| blocklist.add(entries))
+            {
+                Ok(outcome) => RpcMsgResp::BlocklistAddResp(outcome),
+                Err(error) => RpcMsgResp::ServerError(error.to_string()),
+            }
+        }
+        RpcMsgReq::BlocklistRemove { addresses } => {
+            match AddressBlocklist::load(maker.data_dir(), maker.config().network)
+                .and_then(|mut blocklist| blocklist.remove(addresses))
+            {
+                Ok(removed) => RpcMsgResp::BlocklistRemoveResp(removed),
+                Err(error) => RpcMsgResp::ServerError(error.to_string()),
             }
         }
     };

--- a/src/maker/taproot_handlers.rs
+++ b/src/maker/taproot_handlers.rs
@@ -179,6 +179,7 @@ fn process_taproot_contract<M: Maker>(
         // Blocks passed while we waited. We have broadcast nothing yet, so aborting
         // here costs only the reserved UTXOs.
         check_sweep_margin(maker, state.timelock)?;
+        maker.screen_funding_tx(&incoming_contract_tx)?;
 
         let incoming_funding_amount = data.amounts[j];
 

--- a/src/taker/api.rs
+++ b/src/taker/api.rs
@@ -29,6 +29,7 @@ use bitcoin::{
 use bitcoind::bitcoincore_rpc::json::ListUnspentResultEntry;
 
 use crate::{
+    blocklist::{AddOutcome, AddressBlocklist, BlocklistEntry},
     lock_debug,
     maker::nostr::NOSTR_RELAYS,
     protocol::{
@@ -163,6 +164,8 @@ pub struct TakerInitConfig {
     pub tor_auth_password: Option<String>,
     /// SOCKS port for Tor.
     pub socks_port: u16,
+    /// Whether funding inputs should be checked against the address blocklist (optional).
+    pub check_blocklist: Option<bool>,
     /// Wallet password (optional).
     pub password: Option<String>,
     /// Connection type (Tor or Clearnet).
@@ -180,6 +183,7 @@ impl Default for TakerInitConfig {
             control_port: None,
             tor_auth_password: None,
             socks_port: 9050,
+            check_blocklist: None,
             password: None,
             connection_type: ConnectionType::Tor,
             nostr_relays: NOSTR_RELAYS.iter().map(|s| s.to_string()).collect(),
@@ -590,6 +594,10 @@ impl Taker {
         // key material, so the cleartext passphrase must not linger in the
         // long-lived server config.
         let wallet = Wallet::load_or_init(&wallet_path, blockchain, config.password.take())?;
+        // Validate the blocklist on startup when screening is enabled.
+        if config.check_blocklist.unwrap_or(false) {
+            AddressBlocklist::load(&data_dir, wallet.store.network)?;
+        }
 
         // Init Watch Service
         let (watch_service, registry, initial_sync_complete) =
@@ -787,6 +795,10 @@ impl Taker {
 
         if let Some(ref tor_auth_password) = config.tor_auth_password {
             taker_config.tor_auth_password = tor_auth_password.clone();
+        }
+
+        if let Some(check_blocklist) = config.check_blocklist {
+            taker_config.check_blocklist = check_blocklist;
         }
 
         #[cfg(not(feature = "integration-test"))]
@@ -2945,6 +2957,44 @@ impl Taker {
         let parsed = MakerAddress::try_from(address)
             .map_err(|e| TakerError::General(format!("Invalid maker address: {e}")))?;
         self.offerbook.remove(&parsed)
+    }
+
+    /// Add a funding-source address to the shared blocklist, or update its label.
+    pub fn add_blocklist_entry(
+        &self,
+        address: String,
+        label: Option<String>,
+    ) -> Result<AddOutcome, TakerError> {
+        let data_dir = self
+            .config
+            .data_dir
+            .clone()
+            .map(Ok)
+            .unwrap_or_else(get_taker_dir)?;
+        let network = self.read_wallet()?.store.network;
+        let mut blocklist =
+            AddressBlocklist::load(&data_dir, network).map_err(TakerError::Blocklist)?;
+
+        blocklist
+            .add(vec![BlocklistEntry::new(address, label)])
+            .map_err(TakerError::Blocklist)
+    }
+
+    /// Remove a funding-source address from the shared blocklist.
+    pub fn remove_blocklist_entry(&self, address: String) -> Result<usize, TakerError> {
+        let data_dir = self
+            .config
+            .data_dir
+            .clone()
+            .map(Ok)
+            .unwrap_or_else(get_taker_dir)?;
+        let network = self.read_wallet()?.store.network;
+        let mut blocklist =
+            AddressBlocklist::load(&data_dir, network).map_err(TakerError::Blocklist)?;
+
+        blocklist
+            .remove(vec![address])
+            .map_err(TakerError::Blocklist)
     }
 
     /// Restore a wallet from a backup file (static — no taker instance needed).

--- a/src/taker/config.rs
+++ b/src/taker/config.rs
@@ -17,6 +17,8 @@ pub struct TakerConfig {
     pub socks_port: u16,
     /// Authentication password for Tor interface
     pub tor_auth_password: String,
+    /// Whether funding inputs should be checked against the address blocklist.
+    pub check_blocklist: bool,
 }
 
 impl Default for TakerConfig {
@@ -25,6 +27,7 @@ impl Default for TakerConfig {
             control_port: 9051,
             socks_port: 9050,
             tor_auth_password: "".to_string(),
+            check_blocklist: false,
         }
     }
 }
@@ -69,6 +72,10 @@ impl TakerConfig {
                 config_map.get("tor_auth_password"),
                 default_config.tor_auth_password,
             ),
+            check_blocklist: parse_field(
+                config_map.get("check_blocklist"),
+                default_config.check_blocklist,
+            ),
         })
     }
 
@@ -82,8 +89,10 @@ control_port = {}
 # Socks port for Tor proxy
 socks_port = {}
 # Authentication password for Tor control interface
-tor_auth_password = {}",
-            self.control_port, self.socks_port, self.tor_auth_password,
+tor_auth_password = {}
+# Check funding inputs against the address blocklist
+check_blocklist = {}",
+            self.control_port, self.socks_port, self.tor_auth_password, self.check_blocklist,
         );
 
         let parent = path.parent().ok_or_else(|| {
@@ -174,6 +183,7 @@ mod tests {
         let contents = r#"
             [taker_config]
             socks_port = 9050
+            check_blocklist = true
         "#;
         let config_path = create_temp_config(contents, "different_data_taker_config.toml");
         let config = TakerConfig::new(Some(&config_path)).unwrap();
@@ -185,6 +195,7 @@ mod tests {
         assert_eq!(
             TakerConfig {
                 socks_port: 9050,         // Configurable via TOML.
+                check_blocklist: true,    // Explicitly enabled at runtime.
                 ..TakerConfig::default()  // Use default for other values.
             },
             config

--- a/src/taker/error.rs
+++ b/src/taker/error.rs
@@ -1,7 +1,7 @@
 //! All Taker-related errors.
 use crate::{
-    error::NetError, protocol::error::ProtocolError, utill::TorError, wallet::WalletError,
-    watch_tower::watcher_error::WatcherError,
+    blocklist::BlocklistError, error::NetError, protocol::error::ProtocolError, utill::TorError,
+    wallet::WalletError, watch_tower::watcher_error::WatcherError,
 };
 use bitcoin::address::ParseError;
 
@@ -20,6 +20,8 @@ pub enum TakerError {
     NotEnoughMakersInOfferBook,
     /// Error related to wallet operations.
     Wallet(WalletError),
+    /// Error raised while screening funding-input sources.
+    Blocklist(BlocklistError),
     /// Error related to network operations.
     Net(NetError),
     /// Error indicating the send amount was not set for a transaction.
@@ -70,6 +72,12 @@ impl From<serde_json::Error> for TakerError {
 impl From<WalletError> for TakerError {
     fn from(value: WalletError) -> Self {
         Self::Wallet(value)
+    }
+}
+
+impl From<BlocklistError> for TakerError {
+    fn from(value: BlocklistError) -> Self {
+        Self::Blocklist(value)
     }
 }
 

--- a/src/taker/legacy_swap.rs
+++ b/src/taker/legacy_swap.rs
@@ -1197,6 +1197,7 @@ impl Taker {
                 let expected_amount = self.expected_amount_for_hop(maker_idx);
                 self.verify_maker_sender_contracts(
                     &req.senders_contract_txs_info,
+                    maker_idx,
                     next_multisig_pubkeys,
                     next_hashlock_pubkeys,
                     refund_locktime,

--- a/src/taker/legacy_verification.rs
+++ b/src/taker/legacy_verification.rs
@@ -19,7 +19,7 @@ use crate::{
         },
         legacy_messages::SenderContractTxInfo,
     },
-    utill::redeemscript_to_scriptpubkey,
+    utill::{get_taker_dir, redeemscript_to_scriptpubkey},
 };
 
 use super::{api::Taker, error::TakerError};
@@ -180,6 +180,7 @@ impl Taker {
     pub(crate) fn verify_maker_sender_contracts(
         &self,
         senders_info: &[SenderContractTxInfo],
+        maker_idx: usize,
         next_multisig_pubkeys: &[PublicKey],
         next_hashlock_pubkeys: &[PublicKey],
         refund_locktime: u16,
@@ -196,7 +197,31 @@ impl Taker {
 
         let expected_hashvalue = Hash160::hash(&self.swap_state()?.preimage);
 
+        // The taker receives only the final maker's outgoing contracts.
+        let is_final_maker = maker_idx + 1 == self.swap_state()?.makers.len();
+        let blocklist_data_dir = if self.config.check_blocklist.unwrap_or(false) && is_final_maker {
+            Some(
+                self.config
+                    .data_dir
+                    .clone()
+                    .map(Ok)
+                    .unwrap_or_else(get_taker_dir)?,
+            )
+        } else {
+            None
+        };
+
         for (i, info) in senders_info.iter().enumerate() {
+            if let Some(data_dir) = &blocklist_data_dir {
+                let wallet = self.read_wallet()?;
+                crate::blocklist::screen_funding_tx(
+                    data_dir,
+                    wallet.store.network,
+                    &wallet,
+                    &info.funding_tx,
+                )?;
+            }
+
             // Validate 2-of-2 multisig format
             check_reedemscript_is_multisig(&info.multisig_redeemscript).map_err(|e| {
                 TakerError::General(format!(

--- a/src/taker/taproot_verification.rs
+++ b/src/taker/taproot_verification.rs
@@ -10,9 +10,12 @@ use bitcoin::{
     PublicKey,
 };
 
-use crate::protocol::{
-    contract::sum_claimed_amounts, contract2::extract_hash_from_hashlock,
-    musig_interface::get_aggregated_pubkey_compat, taproot_messages::TaprootContractData,
+use crate::{
+    protocol::{
+        contract::sum_claimed_amounts, contract2::extract_hash_from_hashlock,
+        musig_interface::get_aggregated_pubkey_compat, taproot_messages::TaprootContractData,
+    },
+    utill::get_taker_dir,
 };
 
 use super::{api::Taker, error::TakerError};
@@ -147,10 +150,28 @@ impl Taker {
         }
 
         let secp = Secp256k1::verification_only();
+        // The taker receives only the final maker's outgoing contracts.
+        let is_final_maker = maker_idx + 1 == self.swap_state()?.makers.len();
+        let blocklist_data_dir = if self.config.check_blocklist.unwrap_or(false) && is_final_maker {
+            Some(
+                self.config
+                    .data_dir
+                    .clone()
+                    .map(Ok)
+                    .unwrap_or_else(get_taker_dir)?,
+            )
+        } else {
+            None
+        };
 
         // Each contract has its own timelock script, internal key and tap tweak,
         // so verify the timelock template, locktime value and P2TR output per contract.
         for (i, tx) in contract.contract_txs.iter().enumerate() {
+            if let Some(data_dir) = &blocklist_data_dir {
+                let wallet = self.read_wallet()?;
+                crate::blocklist::screen_funding_tx(data_dir, wallet.store.network, &wallet, tx)?;
+            }
+
             let timelock_script = &contract.timelock_scripts[i];
             verify_internal_key(
                 contract.internal_keys[i],

--- a/src/wallet/api.rs
+++ b/src/wallet/api.rs
@@ -3207,6 +3207,43 @@ impl Wallet {
             abort_check,
         )
     }
+
+    /// Resolve the previous-output scripts for every input in a transaction.
+    ///
+    /// Parent transactions are cached for the duration of this call so inputs
+    /// spending multiple outputs from one parent require only one backend
+    /// lookup.
+    pub fn resolve_input_scripts(
+        &self,
+        tx: &Transaction,
+    ) -> Result<Vec<(OutPoint, ScriptBuf)>, WalletError> {
+        let mut parent_transactions = HashMap::new();
+        let mut resolved = Vec::with_capacity(tx.input.len());
+
+        for input in &tx.input {
+            let outpoint = input.previous_output;
+            let parent = if let Some(parent) = parent_transactions.get(&outpoint.txid) {
+                parent
+            } else {
+                let parent = self.blockchain.get_raw_transaction(&outpoint.txid, None)?;
+                parent_transactions.insert(outpoint.txid, parent);
+                parent_transactions
+                    .get(&outpoint.txid)
+                    .expect("inserted parent transaction")
+            };
+
+            let output = parent.output.get(outpoint.vout as usize).ok_or_else(|| {
+                WalletError::General(format!(
+                    "Input {outpoint} references missing output {}",
+                    outpoint.vout
+                ))
+            })?;
+
+            resolved.push((outpoint, output.script_pubkey.clone()));
+        }
+
+        Ok(resolved)
+    }
 }
 
 /// Wait for the given txs to reach `required_confirms`, returning the highest block

--- a/src/wallet/report.rs
+++ b/src/wallet/report.rs
@@ -14,12 +14,14 @@
 use serde::{Deserialize, Serialize};
 use std::{
     collections::HashMap,
-    fs::OpenOptions,
     path::{Path, PathBuf},
     time::Instant,
 };
 
-use crate::utill::now_unix_secs;
+use crate::{
+    atomic_file::{read_json, write_json_atomically, FileLock},
+    utill::now_unix_secs,
+};
 
 use super::{
     deniability::{proof_from_swapcoins, DeniabilityProof},
@@ -741,51 +743,6 @@ fn wallet_report_path(data_dir: &Path, role: SwapRole, wallet_file_name: Option<
         .join(wallet_report_file_name(data_dir, role, wallet_file_name))
 }
 
-struct LockGuard {
-    path: PathBuf,
-}
-
-impl Drop for LockGuard {
-    fn drop(&mut self) {
-        let _ = std::fs::remove_file(&self.path);
-    }
-}
-
-fn acquire_lock(lock_path: &Path) -> std::io::Result<LockGuard> {
-    const TIMEOUT: std::time::Duration = std::time::Duration::from_secs(5);
-    let mut deadline = std::time::Instant::now() + TIMEOUT;
-    loop {
-        match OpenOptions::new()
-            .write(true)
-            .create_new(true)
-            .open(lock_path)
-        {
-            Ok(_) => {
-                return Ok(LockGuard {
-                    path: lock_path.to_owned(),
-                })
-            }
-            Err(e) if e.kind() == std::io::ErrorKind::AlreadyExists => {
-                if std::time::Instant::now() > deadline {
-                    let is_stale = std::fs::metadata(lock_path)
-                        .and_then(|m| m.modified())
-                        .map(|mtime| mtime.elapsed().unwrap_or_default() > TIMEOUT)
-                        .unwrap_or(true);
-
-                    if is_stale {
-                        std::fs::remove_file(lock_path)?;
-                    } else {
-                        // Owner is still active — extend and keep waiting.
-                        deadline = std::time::Instant::now() + TIMEOUT;
-                    }
-                }
-                std::thread::sleep(std::time::Duration::from_millis(10));
-            }
-            Err(e) => return Err(e),
-        }
-    }
-}
-
 fn write_to_path<F>(file_path: &Path, mutate: F) -> std::io::Result<()>
 where
     F: FnOnce(&mut SwapReportFile),
@@ -797,26 +754,13 @@ where
 
     let lock_path = file_path.with_extension("json.lock");
 
-    let _lock = acquire_lock(&lock_path)?;
+    let _lock = FileLock::acquire(&lock_path)?;
 
-    let mut report_file: SwapReportFile = if file_path.exists() {
-        let content = std::fs::read_to_string(file_path)?;
-        serde_json::from_str(&content).map_err(std::io::Error::other)?
-    } else {
-        SwapReportFile::default()
-    };
+    let mut report_file: SwapReportFile = read_json(file_path)?;
 
     mutate(&mut report_file);
 
-    let json = serde_json::to_string_pretty(&report_file).map_err(std::io::Error::other)?;
-    let tmp_path = file_path.with_extension("partial");
-    {
-        use std::io::Write;
-        let mut tmp = std::fs::File::create(&tmp_path)?;
-        tmp.write_all(json.as_bytes())?;
-        tmp.sync_all()?;
-    }
-    std::fs::rename(&tmp_path, file_path)?;
+    write_json_atomically(file_path, &report_file)?;
 
     log::info!("Saved swap report to: {}", file_path.display());
     Ok(())

--- a/tests/integration/blocklist_rejection.rs
+++ b/tests/integration/blocklist_rejection.rs
@@ -1,0 +1,382 @@
+//! Funding-source blocklist rejection through the real Legacy and Taproot swap paths.
+
+use bitcoin::{Amount, Network};
+use openswap::{
+    blocklist::BlocklistError,
+    maker::{start_server, MakerBehavior},
+    protocol::common_messages::ProtocolVersion,
+    taker::{error::TakerError, SwapParams, TakerBehavior},
+    wallet::AddressType,
+};
+
+use super::test_framework::*;
+
+use std::{sync::atomic::Ordering::Relaxed, thread};
+
+#[test]
+fn maker_rejects_legacy_funding_from_blocked_address() {
+    run_maker_rejection(ProtocolVersion::Legacy);
+}
+
+#[test]
+fn maker_rejects_taproot_funding_from_blocked_address() {
+    run_maker_rejection(ProtocolVersion::Taproot);
+}
+
+#[test]
+fn taker_rejects_legacy_funding_from_blocked_address() {
+    run_taker_rejection(ProtocolVersion::Legacy);
+}
+
+#[test]
+fn taker_rejects_taproot_funding_from_blocked_address() {
+    run_taker_rejection(ProtocolVersion::Taproot);
+}
+
+#[test]
+fn populated_blocklist_is_ignored_when_disabled() {
+    let makers_config_map = vec![(6102, None)];
+    let taker_behaviors = vec![TakerBehavior::Normal];
+    let maker_behaviors = vec![MakerBehavior::Normal];
+    let (test_framework, mut takers, makers, block_generation_handle) =
+        TestFramework::init::<BitcoindBackend>(makers_config_map, taker_behaviors, maker_behaviors);
+    let bitcoind = &test_framework.bitcoind;
+    let taker = takers.get_mut(0).unwrap();
+
+    let blocked_taker_address = taker
+        .get_wallet()
+        .write()
+        .unwrap()
+        .get_next_external_address(AddressType::P2TR)
+        .unwrap();
+    for _ in 0..3 {
+        send_to_address(
+            bitcoind,
+            &blocked_taker_address,
+            Amount::from_btc(0.05).unwrap(),
+        );
+    }
+    generate_blocks(bitcoind, 1);
+    taker
+        .get_wallet()
+        .write()
+        .unwrap()
+        .sync_and_save(&openswap::utill::NO_SHUTDOWN)
+        .unwrap();
+
+    let maker_deposit_address = makers[0]
+        .wallet
+        .write()
+        .unwrap()
+        .get_next_external_address(AddressType::P2TR)
+        .unwrap();
+    for _ in 0..4 {
+        send_to_address(
+            bitcoind,
+            &maker_deposit_address,
+            Amount::from_btc(0.05).unwrap(),
+        );
+    }
+    generate_blocks(bitcoind, 1);
+    makers[0]
+        .wallet
+        .write()
+        .unwrap()
+        .sync_and_save(&openswap::utill::NO_SHUTDOWN)
+        .unwrap();
+
+    taker
+        .add_blocklist_entry(
+            blocked_taker_address.to_string(),
+            Some("disabled maker-side check".to_string()),
+        )
+        .unwrap();
+
+    let maker_threads = makers
+        .iter()
+        .map(|maker| {
+            let maker = maker.clone();
+            thread::spawn(move || start_server(maker).unwrap())
+        })
+        .collect::<Vec<_>>();
+    wait_for_makers_setup(&makers, 120);
+    makers[0]
+        .wallet
+        .write()
+        .unwrap()
+        .sync_and_save(&openswap::utill::NO_SHUTDOWN)
+        .unwrap();
+
+    let maker_regular_utxos = makers[0]
+        .wallet
+        .read()
+        .unwrap()
+        .list_descriptor_utxo_spend_info();
+    assert_eq!(maker_regular_utxos.len(), 1);
+    let blocked_maker_address = bitcoin::Address::from_script(
+        maker_regular_utxos[0].0.script_pub_key.as_script(),
+        Network::Regtest,
+    )
+    .unwrap();
+    taker
+        .add_blocklist_entry(
+            blocked_maker_address.to_string(),
+            Some("disabled taker-side check".to_string()),
+        )
+        .unwrap();
+
+    let params = SwapParams::new(ProtocolVersion::Legacy, Amount::from_sat(500_000), 1)
+        .with_tx_count(1)
+        .with_required_confirms(1);
+    let summary = taker
+        .prepare_swap(params)
+        .expect("prepare_swap should succeed");
+    taker
+        .start_swap(&summary.swap_id)
+        .expect("a populated blocklist must be ignored when checking is disabled");
+
+    drop(takers);
+    makers
+        .iter()
+        .for_each(|maker| maker.shutdown.store(true, Relaxed));
+    maker_threads
+        .into_iter()
+        .for_each(|handle| handle.join().unwrap());
+    test_framework.stop();
+    block_generation_handle.join().unwrap();
+}
+
+fn run_maker_rejection(protocol: ProtocolVersion) {
+    let makers_config_map = vec![(6102, None), (16102, None)];
+    let taker_behaviors = vec![TakerBehavior::Normal];
+    let maker_behaviors = vec![MakerBehavior::Normal, MakerBehavior::Normal];
+    let (test_framework, mut takers, makers, block_generation_handle) =
+        TestFramework::init_with_blocklist::<BitcoindBackend>(
+            makers_config_map,
+            taker_behaviors,
+            maker_behaviors,
+        );
+    let bitcoind = &test_framework.bitcoind;
+    let taker = takers.get_mut(0).unwrap();
+
+    // Every spendable taker UTXO comes from this address, so whichever coins
+    // funding selects must trigger the maker's source-address check.
+    let blocked_address = taker
+        .get_wallet()
+        .write()
+        .unwrap()
+        .get_next_external_address(AddressType::P2TR)
+        .unwrap();
+    for _ in 0..3 {
+        send_to_address(bitcoind, &blocked_address, Amount::from_btc(0.05).unwrap());
+    }
+    generate_blocks(bitcoind, 1);
+    taker
+        .get_wallet()
+        .write()
+        .unwrap()
+        .sync_and_save(&openswap::utill::NO_SHUTDOWN)
+        .unwrap();
+    assert_eq!(
+        taker
+            .get_wallet()
+            .read()
+            .unwrap()
+            .get_balances()
+            .unwrap()
+            .regular,
+        Amount::from_btc(0.15).unwrap()
+    );
+
+    let outcome = taker
+        .add_blocklist_entry(
+            blocked_address.to_string(),
+            Some("integration test source".to_string()),
+        )
+        .unwrap();
+    assert_eq!(outcome.added, 1);
+    assert_eq!(outcome.updated, 0);
+
+    fund_makers(
+        &makers,
+        bitcoind,
+        4,
+        Amount::from_btc(0.05).unwrap(),
+        AddressType::P2TR,
+    );
+
+    let maker_threads = makers
+        .iter()
+        .map(|maker| {
+            let maker = maker.clone();
+            thread::spawn(move || start_server(maker).unwrap())
+        })
+        .collect::<Vec<_>>();
+    wait_for_makers_setup(&makers, 120);
+    for maker in &makers {
+        maker
+            .wallet
+            .write()
+            .unwrap()
+            .sync_and_save(&openswap::utill::NO_SHUTDOWN)
+            .unwrap();
+    }
+    let maker_spendable_before = verify_maker_pre_swap_balances(&makers);
+
+    let params = SwapParams::new(protocol, Amount::from_sat(500_000), 2)
+        .with_tx_count(1)
+        .with_required_confirms(1);
+    let summary = taker
+        .prepare_swap(params)
+        .expect("prepare_swap should succeed");
+    assert!(
+        taker.start_swap(&summary.swap_id).is_err(),
+        "the first maker must reject funding from the blocked source address"
+    );
+
+    for (maker, spendable_before) in makers.iter().zip(maker_spendable_before) {
+        maker
+            .wallet
+            .write()
+            .unwrap()
+            .sync_and_save(&openswap::utill::NO_SHUTDOWN)
+            .unwrap();
+        assert_eq!(
+            maker
+                .wallet
+                .read()
+                .unwrap()
+                .get_balances()
+                .unwrap()
+                .spendable,
+            spendable_before,
+            "blocklist rejection must happen before maker liquidity is spent"
+        );
+    }
+
+    drop(takers);
+    makers
+        .iter()
+        .for_each(|maker| maker.shutdown.store(true, Relaxed));
+    maker_threads
+        .into_iter()
+        .for_each(|handle| handle.join().unwrap());
+    test_framework.stop();
+    block_generation_handle.join().unwrap();
+}
+
+fn run_taker_rejection(protocol: ProtocolVersion) {
+    let makers_config_map = vec![(6102, None)];
+    let taker_behaviors = vec![TakerBehavior::Normal];
+    let maker_behaviors = vec![MakerBehavior::Normal];
+    let (test_framework, mut takers, makers, block_generation_handle) =
+        TestFramework::init_with_blocklist::<BitcoindBackend>(
+            makers_config_map,
+            taker_behaviors,
+            maker_behaviors,
+        );
+    let bitcoind = &test_framework.bitcoind;
+    let taker = takers.get_mut(0).unwrap();
+
+    fund_taker(
+        taker,
+        bitcoind,
+        3,
+        Amount::from_btc(0.05).unwrap(),
+        AddressType::P2TR,
+    );
+
+    // Reuse one maker address for the initial deposits. Fidelity setup later
+    // consolidates them into the regular UTXO used for swap funding.
+    let maker_deposit_address = makers[0]
+        .wallet
+        .write()
+        .unwrap()
+        .get_next_external_address(AddressType::P2TR)
+        .unwrap();
+    for _ in 0..4 {
+        send_to_address(
+            bitcoind,
+            &maker_deposit_address,
+            Amount::from_btc(0.05).unwrap(),
+        );
+    }
+    generate_blocks(bitcoind, 1);
+    makers[0]
+        .wallet
+        .write()
+        .unwrap()
+        .sync_and_save(&openswap::utill::NO_SHUTDOWN)
+        .unwrap();
+    assert_eq!(
+        makers[0]
+            .wallet
+            .read()
+            .unwrap()
+            .get_balances()
+            .unwrap()
+            .regular,
+        Amount::from_btc(0.20).unwrap()
+    );
+
+    let maker_threads = makers
+        .iter()
+        .map(|maker| {
+            let maker = maker.clone();
+            thread::spawn(move || start_server(maker).unwrap())
+        })
+        .collect::<Vec<_>>();
+    wait_for_makers_setup(&makers, 120);
+    makers[0]
+        .wallet
+        .write()
+        .unwrap()
+        .sync_and_save(&openswap::utill::NO_SHUTDOWN)
+        .unwrap();
+
+    // Fidelity creation spends the deposits above. Block the resulting
+    // regular change UTXO, which is the actual input to maker swap funding.
+    let maker_regular_utxos = makers[0]
+        .wallet
+        .read()
+        .unwrap()
+        .list_descriptor_utxo_spend_info();
+    assert_eq!(maker_regular_utxos.len(), 1);
+    let blocked_address = bitcoin::Address::from_script(
+        maker_regular_utxos[0].0.script_pub_key.as_script(),
+        Network::Regtest,
+    )
+    .unwrap();
+    let outcome = taker
+        .add_blocklist_entry(
+            blocked_address.to_string(),
+            Some("integration test maker source".to_string()),
+        )
+        .unwrap();
+    assert_eq!(outcome.added, 1);
+    assert_eq!(outcome.updated, 0);
+
+    let params = SwapParams::new(protocol, Amount::from_sat(500_000), 1)
+        .with_tx_count(1)
+        .with_required_confirms(1);
+    let summary = taker
+        .prepare_swap(params)
+        .expect("prepare_swap should succeed");
+    match taker.start_swap(&summary.swap_id) {
+        Err(TakerError::Blocklist(BlocklistError::BlockedAddress { entry, .. })) => {
+            assert_eq!(entry.address, blocked_address.to_string());
+        }
+        Err(other) => panic!("expected blocked-address error, got {:?}", other),
+        Ok(_) => panic!("the taker accepted funding from the maker's blocked source address"),
+    }
+
+    drop(takers);
+    makers
+        .iter()
+        .for_each(|maker| maker.shutdown.store(true, Relaxed));
+    maker_threads
+        .into_iter()
+        .for_each(|handle| handle.join().unwrap());
+    test_framework.stop();
+    block_generation_handle.join().unwrap();
+}

--- a/tests/integration/blocklist_rejection.rs
+++ b/tests/integration/blocklist_rejection.rs
@@ -34,7 +34,16 @@ fn taker_rejects_taproot_funding_from_blocked_address() {
 }
 
 #[test]
-fn populated_blocklist_is_ignored_when_disabled() {
+fn legacy_populated_blocklist_is_ignored_when_disabled() {
+    run_disabled_blocklist(ProtocolVersion::Legacy);
+}
+
+#[test]
+fn taproot_populated_blocklist_is_ignored_when_disabled() {
+    run_disabled_blocklist(ProtocolVersion::Taproot);
+}
+
+fn run_disabled_blocklist(protocol: ProtocolVersion) {
     let makers_config_map = vec![(6102, None)];
     let taker_behaviors = vec![TakerBehavior::Normal];
     let maker_behaviors = vec![MakerBehavior::Normal];
@@ -125,7 +134,7 @@ fn populated_blocklist_is_ignored_when_disabled() {
         )
         .unwrap();
 
-    let params = SwapParams::new(ProtocolVersion::Legacy, Amount::from_sat(500_000), 1)
+    let params = SwapParams::new(protocol, Amount::from_sat(500_000), 1)
         .with_tx_count(1)
         .with_required_confirms(1);
     let summary = taker
@@ -368,6 +377,42 @@ fn run_taker_rejection(protocol: ProtocolVersion) {
         }
         Err(other) => panic!("expected blocked-address error, got {:?}", other),
         Ok(_) => panic!("the taker accepted funding from the maker's blocked source address"),
+    }
+
+    // The maker broadcast its funding before the taker rejected it, so those
+    // coins stay locked in a contract until the timelock matures and the maker
+    // sweeps them back. Rejecting must not strand maker funds.
+    thread::sleep(timelock_recovery_wait::<BitcoindBackend>());
+
+    for (i, maker) in makers.iter().enumerate() {
+        maker
+            .wallet
+            .write()
+            .unwrap()
+            .sync_and_save(&openswap::utill::NO_SHUTDOWN)
+            .unwrap();
+        let maker_balances = maker.wallet.read().unwrap().get_balances().unwrap();
+        println!(
+            "Maker {} balances after recovery: Regular: {}, Swap: {}, Contract: {}, Spendable: {}",
+            i,
+            maker_balances.regular,
+            maker_balances.swap,
+            maker_balances.contract,
+            maker_balances.spendable,
+        );
+        assert_eq!(
+            maker_balances.contract.to_sat(),
+            0,
+            "Maker {} contract balance mismatch",
+            i
+        );
+        assert_eq!(
+            maker_balances.swap.to_sat(),
+            0,
+            "Maker {} swap balance mismatch",
+            i
+        );
+        assert_eq!(maker_balances.fidelity, Amount::from_btc(0.05).unwrap());
     }
 
     drop(takers);

--- a/tests/integration/main.rs
+++ b/tests/integration/main.rs
@@ -10,6 +10,7 @@ mod abort2_case3;
 mod abort3_case1;
 mod abort3_case2;
 mod abort3_case3;
+mod blocklist_rejection;
 mod electrum_abort1;
 mod electrum_list_transactions;
 mod electrum_swap;

--- a/tests/integration/test_framework/mod.rs
+++ b/tests/integration/test_framework/mod.rs
@@ -681,6 +681,36 @@ impl TestFramework {
         taker_behavior: Vec<TakerBehavior>,
         maker_behaviors: Vec<MakerBehavior>,
     ) -> (Arc<Self>, Vec<Taker>, Vec<Arc<MakerServer>>, JoinHandle<()>) {
+        Self::init_with_blocklist_setting::<B>(
+            makers_config_map,
+            taker_behavior,
+            maker_behaviors,
+            false,
+        )
+    }
+
+    /// Initialize the test framework with runtime blocklist screening enabled.
+    #[allow(clippy::type_complexity)]
+    pub fn init_with_blocklist<B: TestBackend>(
+        makers_config_map: Vec<(u16, Option<u16>)>,
+        taker_behavior: Vec<TakerBehavior>,
+        maker_behaviors: Vec<MakerBehavior>,
+    ) -> (Arc<Self>, Vec<Taker>, Vec<Arc<MakerServer>>, JoinHandle<()>) {
+        Self::init_with_blocklist_setting::<B>(
+            makers_config_map,
+            taker_behavior,
+            maker_behaviors,
+            true,
+        )
+    }
+
+    #[allow(clippy::type_complexity)]
+    fn init_with_blocklist_setting<B: TestBackend>(
+        makers_config_map: Vec<(u16, Option<u16>)>,
+        taker_behavior: Vec<TakerBehavior>,
+        maker_behaviors: Vec<MakerBehavior>,
+        check_blocklist: bool,
+    ) -> (Arc<Self>, Vec<Taker>, Vec<Arc<MakerServer>>, JoinHandle<()>) {
         // Setup directory — use a unique suffix so tests can run in parallel
         let unique_id = format!("openswap-{}", rand::random::<u64>());
         let temp_dir = env::temp_dir().join(unique_id);
@@ -733,6 +763,7 @@ impl TestFramework {
                     // Wallet files are always encrypted; tests use a fixed
                     // passphrase (PBKDF2 rounds are 1 under `integration-test`).
                     config.password = Some("integration-test".to_string());
+                    config.check_blocklist = Some(check_blocklist);
                     let mut taker = Taker::init(config).unwrap();
                     taker.behavior = behavior;
                     taker
@@ -763,6 +794,7 @@ impl TestFramework {
                         time_relative_fee_pct: 0.0001,
                         min_swap_amount: 10_000,
                         required_confirms: 1,
+                        check_blocklist,
                         supported_protocols: vec![
                             ProtocolVersion::Legacy,
                             ProtocolVersion::Taproot,

--- a/tests/integration/test_framework/mod.rs
+++ b/tests/integration/test_framework/mod.rs
@@ -644,6 +644,9 @@ pub struct TestFramework {
     /// Kept so [`TestFramework::taker_init_config`] can rebuild the same backend
     /// config the takers were started with.
     zmq_addr: String,
+    /// Kept for the same reason as `zmq_addr`: a taker rebuilt by
+    /// [`TestFramework::taker_init_config`] must screen as the original did.
+    check_blocklist: bool,
     shutdown: AtomicBool,
     block_gen_paused: AtomicBool,
     nostr_relay: Mutex<Option<Child>>,
@@ -825,6 +828,7 @@ impl TestFramework {
             temp_dir: temp_dir.clone(),
             nostr_relay_url: nostr_relay_url.clone(),
             zmq_addr,
+            check_blocklist,
             shutdown: AtomicBool::new(false),
             block_gen_paused: AtomicBool::new(false),
             nostr_relay: Mutex::new(Some(nostr_relay)),
@@ -889,6 +893,7 @@ impl TestFramework {
         // Must match the passphrase set in `TestFramework::init`, or the
         // re-init cannot decrypt the wallet.
         config.password = Some("integration-test".to_string());
+        config.check_blocklist = Some(self.check_blocklist);
         config
     }
 


### PR DESCRIPTION
## Summary

Adds optional funding-source address blocklist screening for Legacy and Taproot swaps.

Fixes #661 

Screening is disabled by default and can be enabled independently for makers and takers:

```toml
check_blocklist = true
```

## Blocklist storage

The maker and taker share the same blocklist:

```text
~/.openswap/
├── blocklist.json
├── maker/
└── taker/
```

## Screening behavior

For each funding input, the previous transaction output is resolved and its `script_pubkey` is compared against the scripts derived from blocklisted addresses.

Each participant screens only the funding it directly receives:

```text
Taker → Maker 1 → Maker 2 → Taker

Maker 1 checks Taker
Maker 2 checks Maker 1
Taker checks Maker 2
```

Intermediate maker-to-maker contracts are not blocklist-screened by the taker.

Additional behavior:

- A missing file is treated as an empty blocklist.
- An empty blocklist avoids previous-transaction queries.
- A malformed or unreadable file returns an error when screening is enabled.
- An unresolvable funding input returns an error.
- A matching input rejects the swap with the address, outpoint, and optional label.
- Addresses are validated against the active Bitcoin network.
- Concurrent updates are protected by file locking and atomic writes.

## Management

Maker commands:

```text
maker-cli blocklist-add <address> --label <label>
maker-cli blocklist-remove <address>
```

Taker commands:

```text
taker blocklist-add <address> --label <label>
taker blocklist-remove <address>
```

Adding an existing address updates its label. Batch operations reject the entire update if any supplied address is invalid.

## Review guide

1. `src/blocklist.rs` — storage, validation, and screening
2. `src/atomic_file.rs` — file locking and atomic JSON writes
3. `src/wallet/api.rs` — funding-input resolution
4. Maker Legacy and Taproot handlers
5. Taker Legacy and Taproot verification
6. CLI, RPC, configuration, and integration tests

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added an optional funding-source blocklist for makers and takers.
  - Added CLI and API commands to add, update, remove, and label blocked addresses.
  - Added network-aware address validation and persistent blocklist management.
  - Added configurable screening during Legacy and Taproot swaps.
  - Added clear operation results and rejection errors for blocked funding sources.

- **Bug Fixes**
  - Improved file updates with locking and atomic writes to prevent corruption during concurrent changes.

- **Documentation**
  - Added guidance on configuring and using the funding-source blocklist.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->