### PR TITLE
feat(swap_report): replace contract txids with swap UTXOs

### DIFF
--- a/src/maker/api.rs
+++ b/src/maker/api.rs
@@ -25,7 +25,7 @@ use crate::{
     wallet::{
         swapcoin::{IncomingSwapCoin, OutgoingSwapCoin},
         AddressType, AnyBlockchain, BackendConfig, Blockchain, CoreRpcConfig, FidelityError,
-        Wallet, WalletError, MAX_FIDELITY_TIMELOCK, MIN_FIDELITY_TIMELOCK,
+        RecoveryOutcome, Wallet, WalletError, MAX_FIDELITY_TIMELOCK, MIN_FIDELITY_TIMELOCK,
     },
     watch_tower::service::WatchService,
 };
@@ -1404,7 +1404,27 @@ impl MakerTrait for MakerServer {
             .map_err(MakerError::Wallet)
     }
 
-    fn sweep_incoming_swapcoins(&self) -> Result<(), MakerError> {
+    fn get_raw_transaction(&self, txid: &bitcoin::Txid) -> Result<Transaction, MakerError> {
+        let chain = lock_debug!(self.wallet.read())
+            .map_err(|_| MakerError::General("Failed to lock wallet"))?
+            .blockchain
+            .new_connection()
+            .map_err(MakerError::Wallet)?;
+        let transaction = chain
+            .get_raw_transaction(txid, None)
+            .map_err(MakerError::Wallet)?;
+        if transaction.compute_txid() != *txid {
+            return Err(MakerError::General(
+                "backend returned an unexpected transaction",
+            ));
+        }
+        Ok(transaction)
+    }
+
+    fn sweep_incoming_swapcoins(
+        &self,
+        incoming_swapcoins: &[IncomingSwapCoin],
+    ) -> Result<RecoveryOutcome, MakerError> {
         log::info!(
             "[{}] Sweeping coins after successful swap",
             self.config.network_port
@@ -1417,9 +1437,18 @@ impl MakerTrait for MakerServer {
             .blockchain
             .new_connection()
             .map_err(MakerError::Wallet)?;
-        let sweep_outcome =
-            Wallet::sweep_incoming_swapcoins(&self.wallet, &chain, MIN_FEE_RATE, &self.shutdown)
-                .map_err(MakerError::Wallet)?;
+        let contract_txids = incoming_swapcoins
+            .iter()
+            .map(|swapcoin| swapcoin.contract_tx.compute_txid())
+            .collect();
+        let sweep_outcome = Wallet::sweep_incoming_swapcoins(
+            &self.wallet,
+            &chain,
+            MIN_FEE_RATE,
+            &self.shutdown,
+            Some(&contract_txids),
+        )
+        .map_err(MakerError::Wallet)?;
 
         if !sweep_outcome.is_empty() {
             log::info!(
@@ -1439,7 +1468,7 @@ impl MakerTrait for MakerServer {
             .sync_and_save(&self.shutdown)
             .map_err(MakerError::Wallet)?;
 
-        Ok(())
+        Ok(sweep_outcome)
     }
 
     fn store_connection_state(
@@ -1912,14 +1941,16 @@ impl MakerTrait for MakerServer {
                 &contract_redeemscript,
             )?;
 
-            outgoing_swapcoins.push(OutgoingSwapCoin::new_legacy(
+            let mut outgoing_swapcoin = OutgoingSwapCoin::new_legacy(
                 my_multisig_privkey,
                 other_multisig_pubkey,
                 my_senders_contract_tx,
                 contract_redeemscript,
                 timelock_privkey,
                 funding_amount,
-            ));
+            );
+            outgoing_swapcoin.funding_tx = Some(my_funding_tx.clone());
+            outgoing_swapcoins.push(outgoing_swapcoin);
         }
 
         let mining_fees = Amount::from_sat(create_funding_txes_result.total_miner_fee);

--- a/src/maker/handlers.rs
+++ b/src/maker/handlers.rs
@@ -1,6 +1,6 @@
 //! Message handlers for the Maker.
 
-use std::{sync::Arc, time::Instant};
+use std::{collections::HashSet, sync::Arc, time::Instant};
 
 use bitcoin::{bip32::ChainCode, Amount, PublicKey, Transaction};
 
@@ -15,7 +15,10 @@ use crate::{
         taproot_messages::TaprootTakerMessage,
     },
     taker::api::REFUND_LOCKTIME_STEP,
-    wallet::swapcoin::{IncomingSwapCoin, OutgoingSwapCoin},
+    wallet::{
+        swapcoin::{IncomingSwapCoin, OutgoingSwapCoin},
+        MakerReport, RecoveryOutcome, ReportUtxo,
+    },
 };
 
 /// Test-only behavior overrides for the maker.
@@ -306,8 +309,14 @@ pub trait Maker: Send + Sync {
     /// Sync wallet with Bitcoin Core and save state to disk.
     fn sync_and_save_wallet(&self) -> Result<(), MakerError>;
 
+    /// Fetch a transaction needed to resolve user-facing report UTXOs.
+    fn get_raw_transaction(&self, txid: &bitcoin::Txid) -> Result<Transaction, MakerError>;
+
     /// Sweep incoming swapcoins after successful swap.
-    fn sweep_incoming_swapcoins(&self) -> Result<(), MakerError>;
+    fn sweep_incoming_swapcoins(
+        &self,
+        incoming_swapcoins: &[IncomingSwapCoin],
+    ) -> Result<RecoveryOutcome, MakerError>;
 
     /// Store connection state for persistence across connections.
     /// `admission` is set only when storing from a fresh SwapDetails message.
@@ -388,6 +397,105 @@ pub trait Maker: Send + Sync {
     /// Get the test behavior override.
     #[cfg(feature = "integration-test")]
     fn behavior(&self) -> MakerBehavior;
+}
+
+pub(super) fn emit_maker_success_report<M: Maker>(
+    maker: &Arc<M>,
+    state: &ConnectionState,
+    swap_id: &str,
+    swept: &RecoveryOutcome,
+) {
+    let network = maker.network();
+    let mut seen_inputs = HashSet::new();
+    let mut outgoing_utxos = Vec::new();
+
+    for swapcoin in &state.outgoing_swapcoins {
+        let funding_tx = match swapcoin.protocol {
+            ProtocolVersion::Legacy => swapcoin.funding_tx.as_ref(),
+            ProtocolVersion::Taproot => Some(&swapcoin.contract_tx),
+        };
+        let Some(funding_tx) = funding_tx else {
+            log::warn!("Missing Legacy funding transaction for swap report");
+            continue;
+        };
+        for input in &funding_tx.input {
+            let outpoint = input.previous_output;
+            if !seen_inputs.insert(outpoint) {
+                continue;
+            }
+            let output = maker
+                .get_raw_transaction(&outpoint.txid)
+                .ok()
+                .and_then(|transaction| transaction.output.get(outpoint.vout as usize).cloned());
+            match output.and_then(|output| ReportUtxo::from_txout(&output, network)) {
+                Some(utxo) => outgoing_utxos.push(utxo),
+                None => log::warn!(
+                    "Failed to resolve outgoing funding input {} for swap report",
+                    outpoint
+                ),
+            }
+        }
+    }
+
+    let incoming_contract_txids: HashSet<_> = state
+        .incoming_swapcoins
+        .iter()
+        .map(|swapcoin| swapcoin.contract_tx.compute_txid())
+        .collect();
+    let incoming_utxos = swept
+        .resolved
+        .iter()
+        .filter(|(contract_txid, _)| incoming_contract_txids.contains(contract_txid))
+        .filter_map(
+            |(_, sweep_txid)| match maker.get_raw_transaction(sweep_txid) {
+                Ok(transaction) => Some(transaction),
+                Err(error) => {
+                    log::warn!(
+                        "Failed to load sweep transaction {} for swap report: {:?}",
+                        sweep_txid,
+                        error
+                    );
+                    None
+                }
+            },
+        )
+        .flat_map(|transaction| transaction.output)
+        .filter_map(|output| ReportUtxo::from_txout(&output, network))
+        .collect();
+
+    let incoming_total = state
+        .incoming_swapcoins
+        .iter()
+        .map(|swapcoin| swapcoin.funding_amount.to_sat())
+        .sum();
+    let outgoing_total = state
+        .outgoing_swapcoins
+        .iter()
+        .map(|swapcoin| swapcoin.funding_amount.to_sat())
+        .sum();
+    let timelock = state
+        .outgoing_swapcoins
+        .first()
+        .and_then(|swapcoin| swapcoin.get_timelock())
+        .unwrap_or(0);
+
+    let report = MakerReport::success(
+        swap_id.to_string(),
+        state.swap_start_time,
+        incoming_total,
+        outgoing_total,
+        state.service_fee_sats,
+        incoming_utxos,
+        outgoing_utxos,
+        timelock,
+        network.to_string(),
+        state.incoming_swapcoins.first(),
+        state.outgoing_swapcoins.first(),
+    );
+    report.print();
+    if let Err(error) = report.save_for_wallet(maker.data_dir(), Some(maker.wallet_name())) {
+        log::warn!("Failed to save maker success report: {error:?}");
+    }
 }
 
 /// Fail closed after admission; persistence limits the check-to-broadcast race.

--- a/src/maker/legacy_handlers.rs
+++ b/src/maker/legacy_handlers.rs
@@ -19,7 +19,7 @@ use crate::{
         legacy_messages::{FundingTxInfo, LegacyTakerMessage},
     },
     utill::{estimate_funding_tx_fee_sats, redeemscript_to_scriptpubkey},
-    wallet::{swapcoin::IncomingSwapCoin, MakerReport, WalletError},
+    wallet::{swapcoin::IncomingSwapCoin, WalletError},
 };
 
 /// Handle a Legacy protocol message.
@@ -882,9 +882,6 @@ fn process_legacy_handover<M: Maker>(
         state.outgoing_swapcoins.len()
     );
 
-    // Generate and save maker success report
-    emit_maker_success_report(maker, state, &handover.id);
-
     #[cfg(feature = "integration-test")]
     {
         use super::handlers::MakerBehavior;
@@ -892,7 +889,7 @@ fn process_legacy_handover<M: Maker>(
             // Sweep here rather than letting the error skip the server loop's
             // sweep block, or the preimage only reaches the chain 30s later via
             // idle recovery and the behavior's name is a lie.
-            if let Err(e) = maker.sweep_incoming_swapcoins() {
+            if let Err(e) = maker.sweep_incoming_swapcoins(&state.incoming_swapcoins) {
                 log::error!("[{}] Test sweep failed: {e:?}", maker.network_port());
             }
             log::warn!(
@@ -935,52 +932,4 @@ fn find_funding_output_index(funding_tx_info: &FundingTxInfo) -> Result<u32, Mak
         .ok_or(MakerError::General(
             "Funding output doesn't match with multisig redeem script",
         ))
-}
-
-/// Emit a maker success report after private key handover.
-fn emit_maker_success_report<M: Maker>(maker: &Arc<M>, state: &ConnectionState, swap_id: &str) {
-    let incoming_total: u64 = state
-        .incoming_swapcoins
-        .iter()
-        .map(|s| s.funding_amount.to_sat())
-        .sum();
-    let outgoing_total: u64 = state
-        .outgoing_swapcoins
-        .iter()
-        .map(|s| s.funding_amount.to_sat())
-        .sum();
-    let incoming_txid = state
-        .incoming_swapcoins
-        .first()
-        .map(|s| s.contract_tx.compute_txid().to_string())
-        .unwrap_or_else(|| "N/A".to_string());
-    let outgoing_txid = state
-        .outgoing_swapcoins
-        .first()
-        .map(|s| s.contract_tx.compute_txid().to_string())
-        .unwrap_or_else(|| "N/A".to_string());
-    let timelock = state
-        .outgoing_swapcoins
-        .first()
-        .and_then(|s| s.get_timelock())
-        .unwrap_or(0);
-    let network = maker.network().to_string();
-
-    let report = MakerReport::success(
-        swap_id.to_string(),
-        state.swap_start_time,
-        incoming_total,
-        outgoing_total,
-        state.service_fee_sats,
-        incoming_txid,
-        outgoing_txid,
-        timelock,
-        network,
-        state.incoming_swapcoins.first(),
-        state.outgoing_swapcoins.first(),
-    );
-    report.print();
-    if let Err(e) = report.save_for_wallet(maker.data_dir(), Some(maker.wallet_name())) {
-        log::warn!("Failed to save maker success report: {:?}", e);
-    }
 }

--- a/src/maker/server.rs
+++ b/src/maker/server.rs
@@ -24,7 +24,9 @@ use crate::{
 use super::{
     api::MakerServer,
     error::MakerError,
-    handlers::{handle_message, ConnectionState, Maker, MAX_CONCURRENT_SWAPS},
+    handlers::{
+        emit_maker_success_report, handle_message, ConnectionState, Maker, MAX_CONCURRENT_SWAPS,
+    },
 };
 
 /// A live swap normally owns a route-heartbeat connection and one protocol
@@ -625,13 +627,17 @@ fn handle_connection(
                 "[{}] Swap completed, sweeping incoming swapcoins",
                 maker.config.network_port
             );
-            if let Err(e) = maker.sweep_incoming_swapcoins() {
-                log::error!(
-                    "[{}] Failed to sweep incoming swapcoins: {:?}",
-                    maker.config.network_port,
-                    e
-                );
-            }
+            let sweep_outcome = match maker.sweep_incoming_swapcoins(&state.incoming_swapcoins) {
+                Ok(outcome) => Some(outcome),
+                Err(e) => {
+                    log::error!(
+                        "[{}] Failed to sweep incoming swapcoins: {:?}",
+                        maker.config.network_port,
+                        e
+                    );
+                    None
+                }
+            };
 
             // Sync wallet after sweep to update UTXO cache.
             if let Err(e) = maker.sync_and_save_wallet() {
@@ -642,29 +648,62 @@ fn handle_connection(
                 );
             }
 
-            // Unwatch all contract outputs now that the swap is complete.
-            for incoming in &state.incoming_swapcoins {
-                let txid = incoming.contract_tx.compute_txid();
-                for (vout, txout) in incoming.contract_tx.output.iter().enumerate() {
-                    maker.unwatch_outpoint(
-                        bitcoin::OutPoint {
-                            txid,
-                            vout: vout as u32,
-                        },
-                        txout.script_pubkey.clone(),
+            let settlement_complete = if let (Some(swap_id), Some(sweep_outcome)) =
+                (state.swap_id.as_ref(), sweep_outcome.as_ref())
+            {
+                let fully_swept = !state.incoming_swapcoins.is_empty()
+                    && state.incoming_swapcoins.iter().all(|swapcoin| {
+                        let contract_txid = swapcoin.contract_tx.compute_txid();
+                        sweep_outcome
+                            .resolved
+                            .iter()
+                            .any(|(resolved_txid, _)| *resolved_txid == contract_txid)
+                    });
+                if fully_swept {
+                    emit_maker_success_report(&maker, &state, swap_id, sweep_outcome);
+                } else {
+                    log::error!(
+                        "[{}] Not writing success report for {}: only {}/{} incoming swapcoins were swept",
+                        maker.config.network_port,
+                        swap_id,
+                        sweep_outcome.resolved.len(),
+                        state.incoming_swapcoins.len()
                     );
                 }
-            }
-            for outgoing in &state.outgoing_swapcoins {
-                let txid = outgoing.contract_tx.compute_txid();
-                for (vout, txout) in outgoing.contract_tx.output.iter().enumerate() {
-                    maker.unwatch_outpoint(
-                        bitcoin::OutPoint {
-                            txid,
-                            vout: vout as u32,
-                        },
-                        txout.script_pubkey.clone(),
-                    );
+                fully_swept
+            } else {
+                false
+            };
+
+            if !settlement_complete {
+                if let Some(ref swap_id) = state.swap_id {
+                    maker.store_connection_state(swap_id, &state, false)?;
+                }
+            } else {
+                // The swap is settled; its contract watches are no longer needed.
+                for incoming in &state.incoming_swapcoins {
+                    let txid = incoming.contract_tx.compute_txid();
+                    for (vout, txout) in incoming.contract_tx.output.iter().enumerate() {
+                        maker.unwatch_outpoint(
+                            bitcoin::OutPoint {
+                                txid,
+                                vout: vout as u32,
+                            },
+                            txout.script_pubkey.clone(),
+                        );
+                    }
+                }
+                for outgoing in &state.outgoing_swapcoins {
+                    let txid = outgoing.contract_tx.compute_txid();
+                    for (vout, txout) in outgoing.contract_tx.output.iter().enumerate() {
+                        maker.unwatch_outpoint(
+                            bitcoin::OutPoint {
+                                txid,
+                                vout: vout as u32,
+                            },
+                            txout.script_pubkey.clone(),
+                        );
+                    }
                 }
             }
 
@@ -1173,11 +1212,17 @@ fn recover_from_swap(
 
             let chain = chain.as_ref().expect("connection created for this branch");
 
+            let contract_txids = incoming_swapcoins
+                .iter()
+                .map(|swapcoin| swapcoin.contract_tx.compute_txid())
+                .collect();
+
             let swept = Wallet::sweep_incoming_swapcoins(
                 &maker.wallet,
                 chain,
                 crate::utill::MIN_FEE_RATE,
                 &maker.shutdown,
+                Some(&contract_txids),
             )
             .map_err(MakerError::Wallet)?;
 

--- a/src/maker/taproot_handlers.rs
+++ b/src/maker/taproot_handlers.rs
@@ -27,7 +27,7 @@ use crate::{
     utill::estimate_funding_tx_fee_sats,
     wallet::{
         swapcoin::{IncomingSwapCoin, OutgoingSwapCoin},
-        MakerReport, WalletError,
+        WalletError,
     },
 };
 
@@ -626,9 +626,6 @@ fn process_taproot_handover<M: Maker>(
         state.outgoing_swapcoins.len()
     );
 
-    // Generate and save maker success report
-    emit_maker_success_report(maker, state, &handover.id);
-
     #[cfg(feature = "integration-test")]
     {
         use super::handlers::MakerBehavior;
@@ -636,7 +633,7 @@ fn process_taproot_handover<M: Maker>(
             // Sweep here rather than letting the error skip the server loop's
             // sweep block, or the preimage only reaches the chain 30s later via
             // idle recovery and the behavior's name is a lie.
-            if let Err(e) = maker.sweep_incoming_swapcoins() {
+            if let Err(e) = maker.sweep_incoming_swapcoins(&state.incoming_swapcoins) {
                 log::error!("[{}] Test sweep failed: {e:?}", maker.network_port());
             }
             log::warn!(
@@ -661,52 +658,4 @@ fn process_taproot_handover<M: Maker>(
     Ok(Some(MakerToTakerMessage::TaprootPrivateKeyHandover(
         response,
     )))
-}
-
-/// Emit a maker success report after private key handover.
-fn emit_maker_success_report<M: Maker>(maker: &Arc<M>, state: &ConnectionState, swap_id: &str) {
-    let incoming_total: u64 = state
-        .incoming_swapcoins
-        .iter()
-        .map(|s| s.funding_amount.to_sat())
-        .sum();
-    let outgoing_total: u64 = state
-        .outgoing_swapcoins
-        .iter()
-        .map(|s| s.funding_amount.to_sat())
-        .sum();
-    let incoming_txid = state
-        .incoming_swapcoins
-        .first()
-        .map(|s| s.contract_tx.compute_txid().to_string())
-        .unwrap_or_else(|| "N/A".to_string());
-    let outgoing_txid = state
-        .outgoing_swapcoins
-        .first()
-        .map(|s| s.contract_tx.compute_txid().to_string())
-        .unwrap_or_else(|| "N/A".to_string());
-    let timelock = state
-        .outgoing_swapcoins
-        .first()
-        .and_then(|s| s.get_timelock())
-        .unwrap_or(0);
-    let network = maker.network().to_string();
-
-    let report = MakerReport::success(
-        swap_id.to_string(),
-        state.swap_start_time,
-        incoming_total,
-        outgoing_total,
-        state.service_fee_sats,
-        incoming_txid,
-        outgoing_txid,
-        timelock,
-        network,
-        state.incoming_swapcoins.first(),
-        state.outgoing_swapcoins.first(),
-    );
-    report.print();
-    if let Err(e) = report.save_for_wallet(maker.data_dir(), Some(maker.wallet_name())) {
-        log::warn!("Failed to save maker success report: {:?}", e);
-    }
 }

--- a/src/taker/api.rs
+++ b/src/taker/api.rs
@@ -45,7 +45,8 @@ use crate::{
     wallet::{
         swapcoin::{IncomingSwapCoin, OutgoingSwapCoin, WatchOnlySwapCoin},
         AnyBlockchain, BackendConfig, Blockchain, CoreRpcConfig,
-        MakerFeeInfo as ReportMakerFeeInfo, RecoveryOutcome, SwapStatus, TakerReport, Wallet,
+        MakerFeeInfo as ReportMakerFeeInfo, RecoveryOutcome, ReportUtxo, SwapStatus, TakerReport,
+        Wallet,
     },
     watch_tower::{
         registry_storage::FileRegistry,
@@ -674,6 +675,7 @@ impl Taker {
                 chain,
                 2.0,
                 &crate::utill::NO_SHUTDOWN,
+                None,
             ) {
                 Ok(ref swept) if !swept.is_empty() => {
                     log::info!(
@@ -1268,7 +1270,13 @@ impl Taker {
 
         // Success path: sweep + report (shared by both protocols)
         let swap_id_owned = swap_id.to_string();
-        let expected_incoming_swapcoins = self.swap_state()?.incoming_swapcoins.len();
+        let incoming_contract_txids: HashSet<_> = self
+            .swap_state()?
+            .incoming_swapcoins
+            .iter()
+            .map(|swapcoin| swapcoin.contract_tx.compute_txid())
+            .collect();
+        let expected_incoming_swapcoins = incoming_contract_txids.len();
         // Hoist connection creation so the read guard drops before sweep
         // takes the write lock on the same wallet.
         let chain = self.read_wallet()?.blockchain.new_connection()?;
@@ -1277,6 +1285,7 @@ impl Taker {
             &chain,
             2.0,
             &crate::utill::NO_SHUTDOWN,
+            Some(&incoming_contract_txids),
         )?;
         log::info!("Swept {} incoming swapcoins", swept.resolved.len());
         self.write_wallet()?
@@ -2544,10 +2553,22 @@ impl Taker {
 
         let network = wallet.store.network;
         let wallet_file_name = wallet.get_name().to_string();
+        let incoming_contract_txids: HashSet<_> = swap
+            .incoming_swapcoins
+            .iter()
+            .map(|swapcoin| swapcoin.contract_tx.compute_txid())
+            .collect();
+        let resolved_sweep_txids: HashSet<_> = swept
+            .into_iter()
+            .flat_map(|outcome| outcome.resolved.iter())
+            .filter(|(contract_txid, _)| incoming_contract_txids.contains(contract_txid))
+            .map(|(_, sweep_txid)| *sweep_txid)
+            .collect();
 
         let output_swap_utxos: Vec<(u64, String)> = wallet
             .list_swept_incoming_swap_utxos()
             .iter()
+            .filter(|(utxo, _)| resolved_sweep_txids.contains(&utxo.txid))
             .map(|(utxo, _)| {
                 let address = utxo
                     .address
@@ -2710,29 +2731,47 @@ impl Taker {
             (total_fee as f64 / fee_denominator as f64) * 100.0
         };
 
-        // Contract txids
-        let outgoing_contract_txid = if !swap.outgoing_swapcoins.is_empty() {
-            Some(
-                swap.outgoing_swapcoins
-                    .iter()
-                    .map(|sc| sc.contract_tx.compute_txid().to_string())
-                    .collect::<Vec<_>>()
-                    .join(", "),
-            )
-        } else {
-            None
-        };
+        let funding_inputs: HashSet<OutPoint> = swap
+            .outgoing_swapcoins
+            .iter()
+            .filter_map(|swapcoin| match swapcoin.protocol {
+                ProtocolVersion::Legacy => swapcoin.funding_tx.as_ref(),
+                ProtocolVersion::Taproot => Some(&swapcoin.contract_tx),
+            })
+            .flat_map(|funding_tx| funding_tx.input.iter().map(|input| input.previous_output))
+            .collect();
+        let outgoing_utxos = initial_utxos
+            .iter()
+            .filter(|utxo| {
+                funding_inputs.contains(&OutPoint {
+                    txid: utxo.txid,
+                    vout: utxo.vout,
+                })
+            })
+            .filter_map(|utxo| {
+                let address = utxo
+                    .address
+                    .as_ref()?
+                    .clone()
+                    .require_network(network)
+                    .ok()?;
+                Some(ReportUtxo {
+                    address: address.to_string(),
+                    value: utxo.amount.to_sat(),
+                })
+            })
+            .collect();
 
-        let incoming_contract_txid = if !swap.incoming_swapcoins.is_empty() {
-            Some(
-                swap.incoming_swapcoins
-                    .iter()
-                    .map(|sc| sc.contract_tx.compute_txid().to_string())
-                    .collect::<Vec<_>>()
-                    .join(", "),
-            )
+        let incoming_utxos = if payment.is_some() {
+            Vec::new()
         } else {
-            None
+            output_swap_utxos
+                .iter()
+                .map(|(value, address)| ReportUtxo {
+                    address: address.clone(),
+                    value: *value,
+                })
+                .collect()
         };
 
         let swap_end_ts = std::time::SystemTime::now()
@@ -2744,7 +2783,11 @@ impl Taker {
             swap_id: swap.id.clone(),
             swap_duration_seconds: swap_duration.as_secs_f64(),
             outgoing_amount: swap.params.send_amount.to_sat(),
-            incoming_amount: total_output_swap_amount,
+            incoming_amount: if payment.is_some() {
+                0
+            } else {
+                total_output_swap_amount
+            },
             fee_paid: total_fee,
             makers_count: maker_count,
             maker_addresses,
@@ -2760,8 +2803,8 @@ impl Taker {
             output_swap_utxos,
             network: network.to_string(),
             error_message,
-            incoming_contract_txid,
-            outgoing_contract_txid,
+            outgoing_utxos,
+            incoming_utxos,
             end_timestamp: swap_end_ts,
             start_timestamp: swap_end_ts.saturating_sub(swap_duration.as_secs()),
             deniability_proof: None,

--- a/src/taker/background_services.rs
+++ b/src/taker/background_services.rs
@@ -87,6 +87,7 @@ impl RecoveryLoop {
                         &chain,
                         2.0,
                         &shutdown_clone,
+                        None,
                     ) {
                         Ok(ref swept) if !swept.is_empty() => {
                             log::info!(

--- a/src/wallet/api.rs
+++ b/src/wallet/api.rs
@@ -988,6 +988,7 @@ impl Wallet {
     ///
     /// The caller supplies the backend connection: the confirmation waits run
     /// on it with no wallet guard held, so a slow tx cannot wedge the wallet.
+    /// This recovery pass is wallet-wide; every eligible outgoing swapcoin is considered.
     pub fn recover_timelocked_swapcoins(
         wallet: &std::sync::RwLock<Wallet>,
         chain: &AnyBlockchain,
@@ -2872,11 +2873,14 @@ impl Wallet {
     ///
     /// The caller supplies the backend connection: the confirmation waits run
     /// on it with no wallet guard held, so a slow tx cannot wedge the wallet.
+    /// `contract_txids` scopes normal settlement to one swap; `None` is reserved
+    /// for startup and background recovery across the whole wallet.
     pub fn sweep_incoming_swapcoins(
         wallet: &std::sync::RwLock<Wallet>,
         chain: &AnyBlockchain,
         feerate: f64,
         shutdown: &std::sync::atomic::AtomicBool,
+        contract_txids: Option<&HashSet<Txid>>,
     ) -> Result<RecoveryOutcome, WalletError> {
         let mut outcome = RecoveryOutcome::default();
 
@@ -2890,7 +2894,10 @@ impl Wallet {
                 .incoming_swapcoins
                 .iter()
                 .filter(|(_, swapcoin)| {
-                    swapcoin.other_privkey.is_some() || swapcoin.hash_preimage.is_some()
+                    (swapcoin.other_privkey.is_some() || swapcoin.hash_preimage.is_some())
+                        && contract_txids.is_none_or(|txids| {
+                            txids.contains(&swapcoin.contract_tx.compute_txid())
+                        })
                 })
                 .map(|(swap_id, swapcoin)| (swap_id.clone(), swapcoin.clone()))
                 .collect();

--- a/src/wallet/ffi.rs
+++ b/src/wallet/ffi.rs
@@ -15,7 +15,7 @@ use super::blockchain::{BackendConfig, Blockchain};
 use std::path::{Path, PathBuf};
 
 pub use super::report::{
-    MakerFeeInfo, MakerReport, RecoveryReport, SwapRole, SwapStatus, TakerReport,
+    MakerFeeInfo, MakerReport, RecoveryReport, ReportUtxo, SwapRole, SwapStatus, TakerReport,
 };
 
 /// Restores a wallet from a JSON backup file for GUI/FFI applications.

--- a/src/wallet/mod.rs
+++ b/src/wallet/mod.rs
@@ -30,7 +30,8 @@ pub(crate) use fidelity::{
     verify_fidelity_checks, FidelityError, MAX_FIDELITY_TIMELOCK, MIN_FIDELITY_TIMELOCK,
 };
 pub use report::{
-    MakerFeeInfo, MakerReport, PaymentResult, RecoveryReport, SwapRole, SwapStatus, TakerReport,
+    MakerFeeInfo, MakerReport, PaymentResult, RecoveryReport, ReportUtxo, SwapRole, SwapStatus,
+    TakerReport,
 };
 pub use spend::Destination;
 pub use storage::AddressType;

--- a/src/wallet/report.rs
+++ b/src/wallet/report.rs
@@ -125,6 +125,25 @@ pub struct PaymentResult {
     pub confirmed: bool,
 }
 
+/// User-facing UTXO information recorded in a swap report.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct ReportUtxo {
+    /// Address locking the reported output.
+    pub address: String,
+    /// Output value in satoshis.
+    pub value: u64,
+}
+
+impl ReportUtxo {
+    pub(crate) fn from_txout(output: &bitcoin::TxOut, network: bitcoin::Network) -> Option<Self> {
+        let address = bitcoin::Address::from_script(&output.script_pubkey, network).ok()?;
+        Some(Self {
+            address: address.to_string(),
+            value: output.value.to_sat(),
+        })
+    }
+}
+
 /// Taker-perspective record for one swap (success or failed).
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct TakerReport {
@@ -145,7 +164,8 @@ pub struct TakerReport {
 
     /// Amount the taker sent (satoshis).
     pub outgoing_amount: u64,
-    /// Amount the taker received back after the swap (satoshis).
+    /// Amount the taker received back after the swap (satoshis). Omitted for PaySwap.
+    #[serde(default, skip_serializing_if = "is_zero")]
     pub incoming_amount: u64,
     /// Total fee paid (outgoing − wallet outputs − settled PaySwap
     /// receiver payment, satoshis).
@@ -157,10 +177,12 @@ pub struct TakerReport {
     /// Total fees paid to all makers (satoshis).
     pub total_maker_fees: u64,
 
-    /// Transaction ID of the taker's outgoing contract.
-    pub outgoing_contract_txid: Option<String>,
-    /// Transaction ID of the taker's incoming contract.
-    pub incoming_contract_txid: Option<String>,
+    /// Wallet UTXOs spent to fund the taker's outgoing contract transactions.
+    pub outgoing_utxos: Vec<ReportUtxo>,
+    /// Final wallet UTXOs created by sweeping the taker's incoming swapcoins.
+    /// Omitted for PaySwap because its settlement outputs belong to the receiver.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub incoming_utxos: Vec<ReportUtxo>,
     /// Funding transaction IDs organised by hop.
     pub funding_txids: Vec<Vec<String>>,
 
@@ -175,16 +197,18 @@ pub struct TakerReport {
     pub input_utxos: Vec<u64>,
     /// Change output amounts returned to the regular wallet (satoshis).
     pub output_change_amounts: Vec<u64>,
-    /// Swap output amounts received from the swap (satoshis).
+    /// Swap output amounts received by the taker (satoshis).
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub output_swap_amounts: Vec<u64>,
     /// Change UTXOs with amounts and addresses.
     pub output_change_utxos: Vec<(u64, String)>,
-    /// Swap UTXOs with amounts and addresses.
+    /// Swap UTXOs received by the taker, with amounts and addresses.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub output_swap_utxos: Vec<(u64, String)>,
     /// Deniability proof for this swap, if successfully generated.
     pub deniability_proof: Option<DeniabilityProof>,
     /// PaySwap outcome; present only when the swap paid a third-party receiver.
-    #[serde(default)]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub payment: Option<PaymentResult>,
 }
 
@@ -302,15 +326,11 @@ impl TakerReport {
         }
 
         println!("\n\x1b[1;36m--------------------------------------------------------------------------------");
-        println!("                            Transaction IDs");
+        println!("                              Swap UTXOs");
         println!("--------------------------------------------------------------------------------\x1b[0m");
 
-        if let Some(ref txid) = self.outgoing_contract_txid {
-            println!("\x1b[1;37mOutgoing Contract :\x1b[0m {}", txid);
-        }
-        if let Some(ref txid) = self.incoming_contract_txid {
-            println!("\x1b[1;37mIncoming Contract :\x1b[0m {}", txid);
-        }
+        print_report_utxos("Outgoing UTXO", &self.outgoing_utxos);
+        print_report_utxos("Incoming UTXO", &self.incoming_utxos);
         if !self.funding_txids.is_empty() {
             println!("\x1b[1;37mFunding Txs       :\x1b[0m");
             for (hop_idx, hop_txids) in self.funding_txids.iter().enumerate() {
@@ -375,6 +395,22 @@ impl TakerReport {
     }
 }
 
+fn is_zero(value: &u64) -> bool {
+    *value == 0
+}
+
+fn print_report_utxos(label: &str, utxos: &[ReportUtxo]) {
+    for (index, utxo) in utxos.iter().enumerate() {
+        println!(
+            "  {:<19} {}. {} ({} sats)",
+            label,
+            index + 1,
+            utxo.address,
+            utxo.value
+        );
+    }
+}
+
 /// Maker-perspective record for one swap.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct MakerReport {
@@ -398,10 +434,10 @@ pub struct MakerReport {
     /// Maker service fee earned, excluding maker-side mining-fee reimbursement.
     pub fee_earned: u64,
 
-    /// Transaction ID of the incoming contract.
-    pub incoming_contract_txid: String,
-    /// Transaction ID of the outgoing contract.
-    pub outgoing_contract_txid: String,
+    /// Final UTXOs created by sweeping the maker's incoming swapcoins.
+    pub incoming_utxos: Vec<ReportUtxo>,
+    /// Wallet UTXOs spent to fund the maker's outgoing contract transactions.
+    pub outgoing_utxos: Vec<ReportUtxo>,
     /// Timelock value in blocks for the outgoing contract.
     pub timelock: u32,
     /// Deniability proof for this swap, if successfully generated.
@@ -416,8 +452,8 @@ impl MakerReport {
         incoming_amount: u64,
         outgoing_amount: u64,
         fee_earned: u64,
-        incoming_contract_txid: String,
-        outgoing_contract_txid: String,
+        incoming_utxos: Vec<ReportUtxo>,
+        outgoing_utxos: Vec<ReportUtxo>,
         timelock: u32,
         network: String,
         incoming: Option<&IncomingSwapCoin>,
@@ -435,8 +471,8 @@ impl MakerReport {
             incoming_amount,
             outgoing_amount,
             fee_earned,
-            incoming_contract_txid,
-            outgoing_contract_txid,
+            incoming_utxos,
+            outgoing_utxos,
             timelock,
             deniability_proof: proof_from_swapcoins(incoming, outgoing, SwapRole::Maker),
         }
@@ -501,17 +537,11 @@ impl MakerReport {
         println!("\x1b[1;37mNetwork           :\x1b[0m {}", self.network);
 
         println!("\n\x1b[1;36m--------------------------------------------------------------------------------");
-        println!("                            Transaction IDs");
+        println!("                              Swap UTXOs");
         println!("--------------------------------------------------------------------------------\x1b[0m");
 
-        println!(
-            "\x1b[1;37mIncoming Contract :\x1b[0m {}",
-            self.incoming_contract_txid
-        );
-        println!(
-            "\x1b[1;37mOutgoing Contract :\x1b[0m {}",
-            self.outgoing_contract_txid
-        );
+        print_report_utxos("Incoming UTXO", &self.incoming_utxos);
+        print_report_utxos("Outgoing UTXO", &self.outgoing_utxos);
 
         println!("\n\x1b[1;36m================================================================================");
         println!("                                END REPORT");
@@ -855,8 +885,8 @@ mod tests {
             mining_fee: 100,
             fee_percentage: 10.0,
             total_maker_fees: 900,
-            outgoing_contract_txid: None,
-            incoming_contract_txid: None,
+            outgoing_utxos: vec![],
+            incoming_utxos: vec![],
             funding_txids: vec![],
             makers_count: 0,
             maker_addresses: vec![],
@@ -869,6 +899,54 @@ mod tests {
             deniability_proof: None,
             payment: None,
         }
+    }
+
+    #[test]
+    fn report_schema_uses_swap_boundary_utxos_without_contract_fields() {
+        let mut report = sample_taker_report();
+        report.outgoing_utxos.push(ReportUtxo {
+            address: "bcrt1qoutgoing".to_string(),
+            value: 10_000,
+        });
+        report.incoming_utxos.push(ReportUtxo {
+            address: "bcrt1qincoming".to_string(),
+            value: 9_500,
+        });
+
+        let serialized = serde_json::to_value(&report).unwrap();
+        assert!(serialized.get("outgoing_contract_txid").is_none());
+        assert!(serialized.get("incoming_contract_txid").is_none());
+        assert!(serialized.get("outgoing_contract_utxos").is_none());
+        assert!(serialized.get("incoming_contract_utxos").is_none());
+        assert_eq!(serialized["outgoing_utxos"][0]["address"], "bcrt1qoutgoing");
+        assert_eq!(serialized["incoming_utxos"][0]["value"], 9_500);
+    }
+
+    #[test]
+    fn payswap_omits_taker_incoming_fields_and_round_trips() {
+        let mut report = sample_taker_report();
+        report.incoming_amount = 0;
+        report.payment = Some(PaymentResult {
+            receiver_address: "bcrt1qreceiver".to_string(),
+            requested_amount: 9_000,
+            delivered_amount: 9_000,
+            settlement_txids: vec!["settlement-txid".to_string()],
+            confirmed: true,
+        });
+
+        let serialized = serde_json::to_value(&report).unwrap();
+        assert!(serialized.get("incoming_amount").is_none());
+        assert!(serialized.get("incoming_utxos").is_none());
+        assert!(serialized.get("output_swap_amounts").is_none());
+        assert!(serialized.get("output_swap_utxos").is_none());
+        assert!(serialized.get("outgoing_utxos").is_some());
+        assert!(serialized.get("payment").is_some());
+
+        let decoded: TakerReport = serde_json::from_value(serialized).unwrap();
+        assert_eq!(decoded.incoming_amount, 0);
+        assert!(decoded.incoming_utxos.is_empty());
+        assert!(decoded.output_swap_amounts.is_empty());
+        assert!(decoded.output_swap_utxos.is_empty());
     }
 
     #[test]

--- a/tests/integration/payswap.rs
+++ b/tests/integration/payswap.rs
@@ -162,6 +162,14 @@ fn test_taproot_payswap() {
     assert!(payment_result.confirmed, "payment must report confirmed");
     assert_eq!(payment_result.requested_amount, payment_amount.to_sat());
     assert_eq!(payment_result.delivered_amount, payment_amount.to_sat());
+    assert_eq!(report.incoming_amount, 0);
+    assert!(report.incoming_utxos.is_empty());
+    assert!(report.output_swap_amounts.is_empty());
+    assert!(report.output_swap_utxos.is_empty());
+    assert!(
+        !report.outgoing_utxos.is_empty(),
+        "PaySwap must still report the taker funding inputs"
+    );
     assert!(
         report.fee_paid < payment_amount.to_sat(),
         "receiver payment principal must not be reported as a fee"
@@ -341,6 +349,14 @@ fn test_legacy_payswap() {
         .expect("payment swap report must carry a payment result");
     assert!(payment_result.confirmed);
     assert_eq!(payment_result.delivered_amount, payment_amount.to_sat());
+    assert_eq!(report.incoming_amount, 0);
+    assert!(report.incoming_utxos.is_empty());
+    assert!(report.output_swap_amounts.is_empty());
+    assert!(report.output_swap_utxos.is_empty());
+    assert!(
+        !report.outgoing_utxos.is_empty(),
+        "PaySwap must still report the taker funding inputs"
+    );
     assert_eq!(
         payment_result.settlement_txids.len(),
         1,


### PR DESCRIPTION
## Summary
Replace incoming/outgoing contract txids in taker and maker swap reports with exact UTXO records containing `address`,  and `value`.

- Reports the actual Legacy funding outpoint and Taproot contract output
- Updates console labels to `Incoming UTXO` and `Outgoing UTXO`
- Removes the old txid-only fields without backward compatibility
- Keeps settlement transactions out of the general swap report

## Checklist
- [x] Tests were added or updated where needed
- [x] Formatting and lints pass
- [x] Documentation was updated where needed
- [x] Security or protocol impact is explained above, if applicable


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Swap reports now include detailed contract UTXO information, including locking addresses and satoshi values.
  * Reports support multiple contract UTXOs and display their details for improved transaction visibility.
  * UTXO report details are available through the wallet interface.
* **Bug Fixes**
  * Improved reporting accuracy for swaps involving multiple contract outputs.
  * Incoming swapcoin recovery is now scoped to the relevant swap when appropriate.
  * PaySwap reports omit non-applicable incoming and output details.
  * Maker success reports are generated after incoming funds are fully swept.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->