### PR TITLE
fix(taker): wait for recovery before the CLI exits

### DIFF
--- a/src/bin/taker.rs
+++ b/src/bin/taker.rs
@@ -648,10 +648,21 @@ fn main() -> Result<(), TakerError> {
                 }
             }
 
-            taker.start_swap(&summary.swap_id)?;
+            // Not `?`: returning here drops the Taker, killing the recovery loop
+            // `start_swap` just spawned. Wait for it first.
+            if let Err(e) = taker.start_swap(&summary.swap_id) {
+                log::error!("Swap failed: {e:?}");
+                if !taker.wait_for_recovery() {
+                    log::warn!("Recovery did not finish; run `taker recover`");
+                }
+                return Err(e);
+            }
         }
         Commands::Recover => {
             taker.recover_active_swap()?;
+            if !taker.wait_for_recovery() {
+                log::warn!("Recovery did not finish; re-run `taker recover`");
+            }
         }
         Commands::Backup => {
             let wallet = lock_debug!(taker.get_wallet().read()).unwrap();

--- a/src/taker/api.rs
+++ b/src/taker/api.rs
@@ -851,6 +851,31 @@ impl Taker {
         }
     }
 
+    /// Block until every unresolved swap contract has been recovered.
+    ///
+    /// Returns whether recovery finished. `false` means contracts are still
+    /// unresolved with nothing retrying them, or that completion could not be
+    /// confirmed.
+    ///
+    /// A refund is unspendable until its timelock matures, so this can block for
+    /// as long as that takes — up to ~1.5 days on mainnet for Legacy. Interrupting
+    /// is safe: each step is persisted as it happens and a re-run resumes.
+    pub fn wait_for_recovery(&mut self) -> bool {
+        if let Some(recovery) = self.recovery_loop.take() {
+            return recovery.join();
+        }
+
+        match self.read_wallet() {
+            Ok(wallet) => {
+                wallet.get_outgoing_swapcoins_count() + wallet.get_incoming_swapcoins_count() == 0
+            }
+            Err(e) => {
+                log::error!("Could not read wallet to check recovery progress: {:?}", e);
+                false
+            }
+        }
+    }
+
     /// Prepare a openswap: discover makers, negotiate, and return a summary.
     ///
     /// No funds are committed. The caller reviews the summary and then calls

--- a/src/taker/background_services.rs
+++ b/src/taker/background_services.rs
@@ -163,7 +163,12 @@ impl RecoveryLoop {
                         None => false,
                     };
 
-                    if all_resolved {
+                    if !all_resolved {
+                        log::info!(
+                            "Recovery loop: contracts still unresolved, retrying in {}s",
+                            RECOVERY_LOOP_INTERVAL.as_secs()
+                        );
+                    } else {
                         log::info!("Recovery loop: all contracts resolved");
                         // Clean up wallet entries and update tracker
                         let swap_ids: Vec<String> = lock_debug!(swap_tracker.lock())
@@ -377,6 +382,23 @@ impl RecoveryLoop {
     /// Check whether recovery is complete.
     pub(crate) fn is_complete(&self) -> bool {
         self.complete.load(Relaxed)
+    }
+
+    /// Block until the loop finishes on its own, reporting whether it resolved
+    /// every contract.
+    ///
+    /// The shutdown flag is left alone so the
+    /// thread runs to its natural end, which it reaches once every contract is
+    /// resolved. Consumes `self` because the join handle is not reusable.
+    pub(crate) fn join(mut self) -> bool {
+        if let Some(handle) = self.handle.take() {
+            if handle.join().is_err() {
+                // Otherwise a panicked thread is indistinguishable from one that
+                // finished the job.
+                log::error!("Recovery loop thread panicked; contracts may be unresolved");
+            }
+        }
+        self.is_complete()
     }
 }
 


### PR DESCRIPTION
## Summary
`start_swap`'s `?` returned from `main`, dropping the `Taker` and killing the recovery loop it had just spawned — the thread ran zero passes. `taker recover` hit the same end via a normal return.

Add `RecoveryLoop::join`, which waits without setting the shutdown flag, and `Taker::wait_for_recovery`, called from both CLI paths before they return. Log per-pass progress so a long wait is not silent.

## Related Issue
Closes #1008 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved swap recovery after opening or manually recovering swaps.
  * Recovery now waits for unresolved contracts to finish before completing.
  * Added clearer warnings when recovery cannot finish successfully.
  * Corrected background recovery behavior so cleanup and status updates occur only after all contracts are resolved.
  * Improved handling of recovery failures and incomplete recovery states.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->