### PR TITLE
fix(protocol): prevent panic on empty funding txes in check_hashvalues_are_equal

### DIFF
--- a/src/protocol/contract.rs
+++ b/src/protocol/contract.rs
@@ -315,13 +315,17 @@ pub(crate) fn check_hashvalues_are_equal(
         .map(|funding_info| read_hashvalue_from_contract(&funding_info.contract_redeemscript))
         .collect::<Result<Vec<_>, ProtocolError>>()?;
 
-    if !hashvalues.iter().all(|value| value == &hashvalues[0]) {
+    let first = hashvalues
+        .first()
+        .ok_or(ProtocolError::General("No confirmed funding txes provided"))?;
+
+    if !hashvalues.iter().all(|value| value == first) {
         return Err(ProtocolError::General(
             "Contract redeemscript doesn't have equal hashvalues",
         ));
     }
 
-    Ok(hashvalues[0])
+    Ok(*first)
 }
 
 /// Read the locktime from a contract redeem script.
@@ -1314,6 +1318,21 @@ mod test {
             error_message_invalid_length,
             "Contract redeemscript doesn't have equal hashvalues"
         );
+
+        // case with empty confirmed funding txes (must not panic)
+        let empty_proof = ProofOfFunding {
+            confirmed_funding_txes: vec![],
+            next_openswap_info: vec![],
+            refund_locktime: u16::default(),
+            contract_feerate: f64::default(),
+            id: "empty".to_string(),
+        };
+        match check_hashvalues_are_equal(&empty_proof).unwrap_err() {
+            ProtocolError::General(msg) => {
+                assert_eq!(msg, "No confirmed funding txes provided");
+            }
+            err => panic!("Unexpected error: {:?}", err),
+        }
     }
 
     #[test]


### PR DESCRIPTION
## Summary                                                                                                                                             
In `src/protocol/contract.rs`, `check_hashvalues_are_equal` verifies that all confirmed funding transactions share identical contract hashvalues.      

When a `ProofOfFunding` message with an empty `confirmed_funding_txes` vector was passed in, `hashvalues` became an empty vector. The closure inside `.all(...)` evaluated vacuously to `true`, and line 324 unconditionally accessed `hashvalues[0]`. This triggered a runtime `index out of bounds: the len is 0 but the index is 0` panic, terminating the thread.

This fix guards the extracted vector using `.first().ok_or(ProtocolError::General("No confirmed funding txes provided"))?`, preventing any panic and  returning a clean error.

## Testing
- Added regression test scenario to `protocol::contract::test::test_check_hashvalues_are_equal` verifying that an empty proof returns `ProtocolError::General("No confirmed funding txes provided")` instead of panicking (verified panic reproduction before the fix).
- Full unit test suite passed: `cargo test --lib` (146 passed, 0 failed).
- Formatting & Clippy passed cleanly with zero warnings:
```
cargo fmt --check
cargo clippy --all-features --lib --bins --tests -- -D warnings
```
## Checklist

[✓] Tests were added or updated where needed
[✓] Formatting and lints pass
[ ] Documentation was updated where needed (N/A)
[✓] Security or protocol impact is explained above, if applicable

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Prevented an application crash when no confirmed funding transactions are available.
  - The system now returns a clear error message for empty funding transaction data.
  - Added coverage to verify this behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->