### PR TITLE
fix(protocol): enforce 21M cap and checked arithmetic in sum_claimed_amounts

### DIFF
--- a/src/protocol/contract.rs
+++ b/src/protocol/contract.rs
@@ -527,7 +527,10 @@ pub(crate) fn sum_claimed_amounts(
         if amount > Amount::MAX_MONEY {
             return Err(amount);
         }
-        total += amount;
+        total = total
+            .checked_add(amount)
+            .filter(|&t| t <= Amount::MAX_MONEY)
+            .ok_or(amount)?;
     }
     Ok(total)
 }
@@ -1326,6 +1329,25 @@ mod test {
         assert_eq!(
             sum_claimed_amounts([normal, normal]),
             Ok(Amount::from_sat(1_000_000))
+        );
+
+        // Multiple amounts that are individually <= MAX_MONEY but whose sum exceeds MAX_MONEY
+        let one_sat = Amount::from_sat(1);
+        assert_eq!(
+            sum_claimed_amounts([Amount::MAX_MONEY, one_sat]),
+            Err(one_sat)
+        );
+
+        let twenty_million_btc = Amount::from_sat(20_000_000 * 100_000_000);
+        assert_eq!(
+            sum_claimed_amounts([twenty_million_btc, twenty_million_btc]),
+            Err(twenty_million_btc)
+        );
+
+        // Many amounts that would overflow u64 must error without panicking
+        assert_eq!(
+            sum_claimed_amounts(std::iter::repeat_n(Amount::MAX_MONEY, 10_000)),
+            Err(Amount::MAX_MONEY)
         );
     }
 }


### PR DESCRIPTION
## Summary                                                                                                                                             
`sum_claimed_amounts` is used by both Legacy and Taproot Taker verifiers (`src/taker/legacy_verification.rs` and `src/taker/taproot_verification.rs`) to validate the total funding and contract amounts claimed by makers.                                                                                    

Previously, while individual amounts were checked against `Amount::MAX_MONEY`, the accumulator used raw addition (`total += amount`). This allowed:    
1. Multiple valid amounts (each <= 21M BTC) whose sum exceeded 21M BTC (e.g. `[20M BTC, 20M BTC]`) to be accepted as `Ok(40M BTC)`, violating Bitcoin's 21M hard cap.
2. Large lists of claimed inputs to cause integer overflow panics in debug builds or wrap-around in release builds.

This fix uses `.checked_add(amount).filter(|&t| t <= Amount::MAX_MONEY).ok_or(amount)?` to ensure the accumulated total is checked for overflow and strictly bounded by `Amount::MAX_MONEY`.

## Testing
- Extended `protocol::contract::test::claimed_amounts_above_the_cap_are_rejected_before_summing` with cases for:
    - Multiple amounts summing to > `MAX_MONEY` (e.g. `[MAX_MONEY, 1 SAT]`, `[20M BTC, 20M BTC]`).
    - Large input iterators that would overflow `u64`.
- Verified test failure on `master` prior to the fix.
- Full unit test suite passed: `cargo test --lib` (146 passed, 0 failed).
- Formatting & Clippy passed cleanly with zero warnings:
```bash
cargo fmt --check
cargo clippy --all-features --lib --bins --tests -- -D warnings
```

## Checklist

- [x] Tests were added or updated where needed
- [x] Formatting and lints pass
- [ ] Documentation was updated where needed (N/A)
- [x] Security or protocol impact is explained above, if applicable

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented claimed-amount totals from exceeding the 21 million cap.
  * Invalid totals now return an error instead of overflowing.
  * Added coverage for repeated maximum amounts, large collections, and individually valid amounts whose combined total exceeds the limit.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->