### PR TITLE
fix(protocol): reject overflowing 3-byte script numbers in read_contract_locktime

### DIFF
--- a/src/protocol/contract.rs
+++ b/src/protocol/contract.rs
@@ -334,9 +334,14 @@ pub(crate) fn read_contract_locktime(redeemscript: &Script) -> Result<u16, Proto
         Instruction::PushBytes(locktime_bytes) => match locktime_bytes.len() {
             1 => Ok(locktime_bytes[0] as u16),
             2 | 3 => {
-                let (int_bytes, _rest) = locktime_bytes
+                let (int_bytes, rest) = locktime_bytes
                     .as_bytes()
                     .split_at(std::mem::size_of::<u16>());
+                if rest.iter().any(|&b| b != 0) {
+                    return Err(ProtocolError::General(
+                        "Can't read locktime value from contract redeemscript",
+                    ));
+                }
                 Ok(u16::from_le_bytes(int_bytes.try_into().map_err(|_| {
                     ProtocolError::General("Can't read locktime value from contract redeemscript")
                 })?))
@@ -637,6 +642,30 @@ mod test {
             hashvalue
         );
         assert_eq!(read_contract_locktime(&contract_script).unwrap(), locktime);
+
+        // A contract with 3-byte locktime exceeding u16 range (e.g. 65536) must error
+        let overflowing_contract = Builder::new()
+            .push_opcode(opcodes::all::OP_SIZE)
+            .push_opcode(opcodes::all::OP_SWAP)
+            .push_opcode(opcodes::all::OP_HASH160)
+            .push_slice(hashvalue.to_byte_array())
+            .push_opcode(opcodes::all::OP_EQUAL)
+            .push_opcode(opcodes::all::OP_IF)
+            .push_key(&pub_hashlock)
+            .push_int(32)
+            .push_int(0)
+            .push_opcode(opcodes::all::OP_ELSE)
+            .push_key(&pub_timelock)
+            .push_int(0)
+            .push_slice([0x00, 0x00, 0x01])
+            .push_opcode(opcodes::all::OP_ENDIF)
+            .push_opcode(opcodes::all::OP_CSV)
+            .push_opcode(opcodes::all::OP_DROP)
+            .push_opcode(opcodes::all::OP_ROT)
+            .push_opcode(opcodes::all::OP_EQUALVERIFY)
+            .push_opcode(opcodes::all::OP_CHECKSIG)
+            .into_script();
+        assert!(read_contract_locktime(&overflowing_contract).is_err());
     }
 
     #[test]


### PR DESCRIPTION
## Summary                                                                                                                                             
In `src/protocol/contract.rs`, `read_contract_locktime` parses the relative locktime opcode from contract redeem scripts across Maker and Taker verifiers (`src/maker/api.rs:1732`, `src/taker/legacy_verification.rs:274` and `src/wallet/swapcoin.rs:1003`).                                          

When parsing 3-byte script numbers (used for positive integers in `[32768..65535]` with a trailing `0x00` sign byte), `read_contract_locktime` split the bytes at 2 bytes and discarded the remainder `_rest`.                                                                                                

If a peer supplied a 3-byte locktime exceeding `u16::MAX` (e.g. 65,536 blocks encoded as `[0x00, 0x00, 0x01]`), the 3rd byte was silently truncated, causing `read_contract_locktime` to return `Ok(0)` instead of rejecting the invalid locktime.                                                            

This fix verifies that any trailing bytes in `rest` are strictly `0x00`, returning `ProtocolError::General("Can't read locktime value from contract redeemscript")` if the value exceeds the `u16` range.

## Testing
- Added regression test in `protocol::contract::test::test_contract_script_generation` checking that 3-byte contract locktimes exceeding `u16::MAX` return an error (verified test failure prior to fix).
- Full unit test suite passed: `cargo test --lib` (146 passed, 0 failed).
- Formatting & Clippy passed cleanly with zero warnings:

```bash
cargo fmt --check
cargo clippy --all-features --lib --bins --tests -- -D warnings
```
## Checklist

[✓] Tests were added or updated where needed
[✓] Formatting and lints pass
[ ] Documentation was updated where needed (N/A)
[✓] Security or protocol impact is explained above, if applicable

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Invalid locktime encodings that exceed the supported 16-bit range are now rejected.
  * Added validation coverage for oversized locktime values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->