### PR TITLE
fix(taker): derive swap id independently of the swap preimage

### DIFF
--- a/docs/taker.md
+++ b/docs/taker.md
@@ -416,6 +416,8 @@ Estimated receive:   18920 sats
 Proceed with this swap? [y/N]
 ```
 
+The swap ID is randomly generated and independent of the swap's cryptographic material, so it cannot be used to locate the swap's contracts on-chain. It is a local handle for referring to the swap, for example with `verify-deniability`.
+
 Confirm with `y` (or pass `-y`/`--yes` upfront) to execute the swap. With `--payment-address <addr>` (PaySwap), the summary instead shows the receiver, the exact amount the receiver gets, and the total openswap cost.
 
 The process typically takes several minutes to complete. You can monitor the swap progress by watching the debug log in a new terminal:

--- a/src/taker/api.rs
+++ b/src/taker/api.rs
@@ -19,7 +19,6 @@ use super::swap_tracker::{
 
 use bitcoin::{
     hashes::{hash160::Hash as Hash160, Hash},
-    hex::DisplayHex,
     secp256k1::{
         rand::{rngs::OsRng, RngCore},
         SecretKey,
@@ -915,7 +914,7 @@ impl Taker {
         let mut preimage = [0u8; 32];
         OsRng.fill_bytes(&mut preimage);
 
-        let swap_id = Hash160::hash(&preimage)[0..8].to_lower_hex_string();
+        let swap_id = format!("{:016x}", OsRng.next_u64());
         log::info!("Preparing openswap with id: {}", swap_id);
 
         let maker_count = params.maker_count;


### PR DESCRIPTION
## Summary
The swap id was the first 8 bytes of Hash160(preimage), which is exactly the hashvalue embedded in the on-chain HTLC. Legacy pushes that hash into the contract redeemscript, and taproot carries SHA256(preimage) in the hashlock leaf, from which one RIPEMD160 recovers the same prefix. Either way the id was a 64-bit-conclusive lookup key into chain data.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Security Improvements**
  - Swap identifiers are now generated independently from the swap preimage, preventing the identifier from revealing or depending on preimage-derived information.

- **Documentation**
  - Clarified that swap IDs are randomly generated local references. They cannot be used to locate swap contracts on-chain and may be used when referring to swaps in verification commands.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->