### PR TITLE
feat(offerbook): prune stale makers and support safe rediscovery

### DIFF
--- a/src/taker/offers.rs
+++ b/src/taker/offers.rs
@@ -6,6 +6,7 @@
 //! It uses asynchronous channels for concurrent processing of maker offers.
 
 use std::{
+    collections::HashMap,
     convert::TryFrom,
     fmt,
     io::BufWriter,
@@ -19,7 +20,7 @@ use std::{
     time::{Duration, SystemTime, UNIX_EPOCH},
 };
 
-use bitcoin::{OutPoint, Txid};
+use bitcoin::OutPoint;
 use serde::{Deserialize, Serialize};
 
 use crate::{
@@ -83,6 +84,11 @@ const DISCOVERY_WAIT_MAX: Duration = Duration::from_secs(10);
 
 const OFFER_SYNC_WAIT_TIMEOUT: Duration = Duration::from_secs(10 * 60);
 
+/// Makers without a successful offer download for this long are removed from
+/// the visible offerbook. Their compact suppression record prevents an
+/// unchanged fidelity announcement from immediately adding them back.
+const STALE_MAKER_AGE: Duration = Duration::from_secs(2 * 24 * 60 * 60);
+
 /// Represents an offer along with the corresponding maker address.
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct OfferAndAddress {
@@ -106,6 +112,10 @@ pub struct MakerOfferCandidate {
     /// Fidelity bond outpoint (txid from registry, vout is always 0).
     pub fidelity_outpoint: Option<OutPoint>,
 
+    /// Fidelity expiry height, when known from discovery or the downloaded offer.
+    #[serde(default)]
+    pub fidelity_expiry_height: Option<u32>,
+
     /// Latest offer, if successfully fetched
     pub offer: Option<Offer>,
 
@@ -117,6 +127,15 @@ pub struct MakerOfferCandidate {
 
     /// Timestamp(secs) of last successful offer download, used to avoid re-downloading offers too frequently.
     pub last_offer_update_ts: Option<u64>,
+
+    /// Timestamp (secs) when this candidate first entered the offerbook. This
+    /// bounds the lifetime of makers that have never returned a valid offer.
+    #[serde(default)]
+    pub first_seen_ts: Option<u64>,
+
+    /// Creation time of the newest verified Nostr announcement seen for this maker.
+    #[serde(default)]
+    pub last_announcement_ts: Option<u64>,
 
     /// Timestamp (secs) after which we will attempt the next offer download, used to back off to makers that are repeatedly unresponsive.
     pub next_offer_check_ts: Option<u64>,
@@ -133,6 +152,7 @@ impl MakerOfferCandidate {
             );
         }
         self.fidelity_outpoint = Some(offer.fidelity.bond.outpoint());
+        self.fidelity_expiry_height = Some(offer.fidelity.bond.lock_time.to_consensus_u32());
         self.offer = Some(offer);
         self.protocol = Some(protocol);
         self.last_offer_update_ts = Some(now_ts);
@@ -362,7 +382,7 @@ impl OfferBookHandle {
     pub fn load_or_create(data_dir: &Path) -> Result<Self, TakerError> {
         let path = data_dir.join("offerbook.json");
 
-        let offerbook = if path.exists() {
+        let mut offerbook = if path.exists() {
             match OfferBook::read_from_disk(&path) {
                 Ok(book) => {
                     log::info!("Successfully loaded offerbook at {path:?}");
@@ -383,6 +403,16 @@ impl OfferBookHandle {
             serde_json::to_writer_pretty(writer, &empty_book)?;
             empty_book
         };
+
+        let now = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap_or(Duration::ZERO)
+            .as_secs();
+        if offerbook.backfill_first_seen_timestamps(now) {
+            // Persist the migration immediately so repeated unclean shutdowns
+            // cannot keep resetting the two-day age of legacy candidates.
+            offerbook.write_to_disk(&path)?;
+        }
 
         Ok(Self {
             inner: Arc::new(RwLock::new(offerbook)),
@@ -562,16 +592,37 @@ impl OfferSyncService {
             }
         };
         let fidelities = self.registry.list_fidelity(height)?;
+
         {
             let mut book = lock_debug!(self.offerbook.inner.write())
                 .map_err(|_| TakerError::General("offerbook lock poisoned".into()))?;
+
+            let pruned = book.prune_stale_makers(now);
+            let expired_suppressions = book.prune_expired_suppressions(height);
+            let mut changed = pruned > 0 || expired_suppressions > 0;
+
             for fidelity in fidelities {
                 match MakerAddress::try_from(fidelity.onion_address) {
-                    Ok(parsed) => book.upsert_address(parsed, Some(fidelity.txid)),
+                    Ok(parsed) => {
+                        changed |= book.upsert_discovered(
+                            parsed,
+                            Some(OutPoint::new(fidelity.txid, 0)),
+                            Some(fidelity.expire_height),
+                            fidelity.last_announcement_ts,
+                            now,
+                        );
+                    }
                     Err(e) => {
                         log::warn!("Skipping invalid maker address from registry: {e}");
                     }
                 }
+            }
+
+            if pruned > 0 {
+                log::info!("Pruned {pruned} makers not synced for at least two days");
+            }
+            if changed {
+                book.write_to_disk(&self.offerbook.path)?;
             }
         }
 
@@ -660,15 +711,15 @@ impl OfferSyncService {
             .unwrap_or(Duration::ZERO)
             .as_secs();
 
-        // Ensure the maker is present in the offerbook before polling.
+        // An explicit poll overrides automatic stale-maker suppression.
         // Same poison policy as fetch_and_record_one: skip this poll.
         match lock_debug!(self.offerbook.inner.write()) {
-            Ok(mut book) => book.upsert_address(address.clone(), None),
+            Ok(mut book) => book.upsert_for_poll(address.clone(), now),
             Err(_) => {
                 log::error!("offerbook lock poisoned; skipping poll of {address}");
                 return None;
             }
-        }
+        };
 
         Self::fetch_and_record_one(
             address,
@@ -926,28 +977,202 @@ fn verify_fidelity_with_backend(
     .map_err(|e| FidelityCheckError::BadBond(TakerError::Wallet(e)))
 }
 
-/// An ephemeral Offerbook tracking good and bad makers. Currently, Offerbook is initiated
-/// at the start of every swap. So good and bad maker list will not be persisted.
+/// Minimal record retained after a stale maker is removed from the visible book.
+/// It prevents an unchanged, still-cached fidelity announcement from recreating
+/// the maker on every sync cycle.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+struct SuppressedMaker {
+    fidelity_outpoint: Option<OutPoint>,
+    fidelity_expiry_height: Option<u32>,
+    last_announcement_ts: Option<u64>,
+    retry_after_ts: u64,
+}
+
+/// Persisted offerbook containing visible maker candidates and compact stale-maker
+/// suppression records.
 #[derive(Debug, Default, Serialize, Deserialize, Clone)]
 pub struct OfferBook {
     pub(super) makers: Vec<MakerOfferCandidate>,
+
+    #[serde(default, skip_serializing_if = "HashMap::is_empty")]
+    suppressed_makers: HashMap<MakerAddress, SuppressedMaker>,
 }
 
 impl OfferBook {
-    fn upsert_address(&mut self, address: MakerAddress, txid: Option<Txid>) {
-        if self.makers.iter().any(|m| m.address == address) {
-            return;
+    /// Adds a maker learned through discovery. Returns whether persisted state
+    /// changed. A suppressed maker is admitted immediately for a different bond,
+    /// while a newer announcement or elapsed cooldown allows one recovery probe.
+    fn upsert_discovered(
+        &mut self,
+        address: MakerAddress,
+        fidelity_outpoint: Option<OutPoint>,
+        fidelity_expiry_height: Option<u32>,
+        last_announcement_ts: Option<u64>,
+        now_ts: u64,
+    ) -> bool {
+        if let Some(existing) = self.makers.iter_mut().find(|m| m.address == address) {
+            let mut changed = false;
+            if existing.fidelity_outpoint.is_none() && fidelity_outpoint.is_some() {
+                existing.fidelity_outpoint = fidelity_outpoint;
+                changed = true;
+            }
+            if existing.fidelity_expiry_height.is_none() && fidelity_expiry_height.is_some() {
+                existing.fidelity_expiry_height = fidelity_expiry_height;
+                changed = true;
+            }
+            if let Some(timestamp) = last_announcement_ts {
+                if existing
+                    .last_announcement_ts
+                    .is_none_or(|previous| timestamp > previous)
+                {
+                    existing.last_announcement_ts = Some(timestamp);
+                    changed = true;
+                }
+            }
+            return changed;
         }
 
+        let recovery_probe = match self.suppressed_makers.get(&address) {
+            Some(suppressed) => {
+                let bond_changed = matches!(
+                    (suppressed.fidelity_outpoint, fidelity_outpoint),
+                    (Some(previous), Some(current)) if previous != current
+                );
+                let announcement_advanced = last_announcement_ts.is_some_and(|timestamp| {
+                    suppressed
+                        .last_announcement_ts
+                        .is_none_or(|previous| timestamp > previous)
+                });
+                if !bond_changed && !announcement_advanced && now_ts < suppressed.retry_after_ts {
+                    return false;
+                }
+                !bond_changed
+            }
+            None => false,
+        };
+
+        self.suppressed_makers.remove(&address);
+        let first_seen_ts = if recovery_probe {
+            // A recovery attempt gets one probe. If it fails, this deliberately
+            // old timestamp returns it to suppression on the following cycle.
+            now_ts.saturating_sub(STALE_MAKER_AGE.as_secs())
+        } else {
+            now_ts
+        };
+        self.insert_candidate(
+            address,
+            fidelity_outpoint,
+            fidelity_expiry_height,
+            last_announcement_ts,
+            first_seen_ts,
+        );
+        true
+    }
+
+    /// Adds a maker for an explicit user-requested poll, bypassing suppression.
+    fn upsert_for_poll(&mut self, address: MakerAddress, now_ts: u64) -> bool {
+        let mut changed = self.suppressed_makers.remove(&address).is_some();
+        if self.makers.iter().any(|m| m.address == address) {
+            return changed;
+        }
+
+        self.insert_candidate(address, None, None, None, now_ts);
+        changed = true;
+        changed
+    }
+
+    fn insert_candidate(
+        &mut self,
+        address: MakerAddress,
+        fidelity_outpoint: Option<OutPoint>,
+        fidelity_expiry_height: Option<u32>,
+        last_announcement_ts: Option<u64>,
+        first_seen_ts: u64,
+    ) {
         self.makers.push(MakerOfferCandidate {
             address,
-            fidelity_outpoint: txid.map(|t| OutPoint::new(t, 0)),
+            fidelity_outpoint,
+            fidelity_expiry_height,
             offer: None,
             state: MakerState::Unresponsive { retries: 0 },
             protocol: None,
             last_offer_update_ts: None,
+            first_seen_ts: Some(first_seen_ts),
+            last_announcement_ts,
             next_offer_check_ts: None,
         });
+    }
+
+    /// Removes makers whose last successful offer is at least two days old.
+    /// Never-successful makers use their first-seen timestamp as the age anchor.
+    fn prune_stale_makers(&mut self, now_ts: u64) -> usize {
+        let before = self.makers.len();
+        let suppressed_makers = &mut self.suppressed_makers;
+
+        self.makers.retain(|maker| {
+            let age_anchor = maker.last_offer_update_ts.or(maker.first_seen_ts);
+            let stale = age_anchor.is_some_and(|timestamp| {
+                now_ts.saturating_sub(timestamp) >= STALE_MAKER_AGE.as_secs()
+            });
+
+            if stale {
+                suppressed_makers.insert(
+                    maker.address.clone(),
+                    SuppressedMaker {
+                        fidelity_outpoint: maker.fidelity_outpoint,
+                        fidelity_expiry_height: maker.fidelity_expiry_height,
+                        last_announcement_ts: maker.last_announcement_ts,
+                        retry_after_ts: now_ts.saturating_add(STALE_MAKER_AGE.as_secs()),
+                    },
+                );
+            }
+
+            !stale
+        });
+
+        before - self.makers.len()
+    }
+
+    /// Drops suppression records once their fidelity bond can no longer be a
+    /// discovery source. Records without known expiry remain until retried.
+    fn prune_expired_suppressions(&mut self, current_height: u32) -> usize {
+        if current_height == 0 {
+            return 0;
+        }
+
+        let before = self.suppressed_makers.len();
+        self.suppressed_makers.retain(|_, suppressed| {
+            suppressed
+                .fidelity_expiry_height
+                .is_none_or(|expiry| expiry > current_height)
+        });
+        before - self.suppressed_makers.len()
+    }
+
+    /// Backfills the first-seen timestamp added with stale-maker pruning. For
+    /// old never-successful records, the scheduled retry gives a conservative
+    /// approximation of when the previous attempt occurred.
+    fn backfill_first_seen_timestamps(&mut self, now_ts: u64) -> bool {
+        let mut changed = false;
+        for maker in &mut self.makers {
+            if maker.first_seen_ts.is_some() {
+                continue;
+            }
+
+            let inferred = maker
+                .last_offer_update_ts
+                .or_else(|| {
+                    maker.next_offer_check_ts.map(|next_check| {
+                        next_check
+                            .saturating_sub(UNRESPONSIVE_MAKER_BACKOFF_STEP.as_secs())
+                            .min(now_ts)
+                    })
+                })
+                .unwrap_or(now_ts);
+            maker.first_seen_ts = Some(inferred);
+            changed = true;
+        }
+        changed
     }
 
     pub(crate) fn mark_success(
@@ -1346,10 +1571,13 @@ mod tests {
         let mut candidate = MakerOfferCandidate {
             address: addr("6104"),
             fidelity_outpoint: Some(OutPoint::new(Txid::from_slice(&[1; 32]).unwrap(), 0)),
+            fidelity_expiry_height: None,
             offer: None,
             state: MakerState::Good,
             protocol: None,
             last_offer_update_ts: None,
+            first_seen_ts: Some(now_ts),
+            last_announcement_ts: None,
             next_offer_check_ts: None,
         };
 
@@ -1386,10 +1614,13 @@ mod tests {
         let mut candidate = MakerOfferCandidate {
             address: addr("6105"),
             fidelity_outpoint: Some(OutPoint::new(Txid::from_slice(&[1; 32]).unwrap(), 0)),
+            fidelity_expiry_height: None,
             offer: None,
             state: MakerState::Bad,
             protocol: None,
             last_offer_update_ts: None,
+            first_seen_ts: Some(now_ts),
+            last_announcement_ts: None,
             next_offer_check_ts: Some(now_ts + 123),
         };
 
@@ -1406,14 +1637,17 @@ mod tests {
     #[test]
     fn makers_to_poll_respects_backoff_timer() {
         let now_ts = 170000;
-        let mut book = OfferBook { makers: vec![] };
+        let mut book = OfferBook::default();
         book.makers.push(MakerOfferCandidate {
             address: addr("6103"),
             fidelity_outpoint: Some(OutPoint::new(Txid::from_slice(&[1; 32]).unwrap(), 0)),
+            fidelity_expiry_height: None,
             offer: None,
             state: MakerState::Unresponsive { retries: 3 },
             protocol: None,
             last_offer_update_ts: None,
+            first_seen_ts: Some(now_ts),
+            last_announcement_ts: None,
             next_offer_check_ts: Some(now_ts + 10),
         });
 
@@ -1428,14 +1662,17 @@ mod tests {
     fn backend_down_leaves_maker_state_unchanged() {
         let now_ts = 170000;
         let address = addr("6106");
-        let mut book = OfferBook { makers: vec![] };
+        let mut book = OfferBook::default();
         book.makers.push(MakerOfferCandidate {
             address: address.clone(),
             fidelity_outpoint: Some(OutPoint::new(Txid::from_slice(&[1; 32]).unwrap(), 0)),
+            fidelity_expiry_height: None,
             offer: None,
             state: MakerState::Good,
             protocol: None,
             last_offer_update_ts: None,
+            first_seen_ts: Some(now_ts),
+            last_announcement_ts: None,
             next_offer_check_ts: None,
         });
 
@@ -1451,6 +1688,200 @@ mod tests {
             book.makers[0].state,
             MakerState::Unresponsive { retries: 1 }
         );
+    }
+
+    #[test]
+    fn stale_pruning_is_inclusive_and_uses_the_right_age_anchor() {
+        let ttl = STALE_MAKER_AGE.as_secs();
+        let now_ts = ttl * 2;
+        let outpoint = Some(OutPoint::new(Txid::from_slice(&[3; 32]).unwrap(), 0));
+        let mut book = OfferBook::default();
+
+        book.insert_candidate(addr("fresh"), outpoint, Some(500), None, 0);
+        book.makers[0].last_offer_update_ts = Some(now_ts - ttl + 1);
+
+        book.insert_candidate(addr("boundary"), outpoint, Some(500), None, now_ts);
+        book.makers[1].last_offer_update_ts = Some(now_ts - ttl);
+
+        book.insert_candidate(addr("never"), outpoint, Some(500), None, now_ts - ttl);
+
+        book.insert_candidate(addr("future"), outpoint, Some(500), None, now_ts);
+        book.makers[3].last_offer_update_ts = Some(now_ts + 1);
+
+        assert_eq!(book.prune_stale_makers(now_ts), 2);
+
+        let remaining: Vec<_> = book
+            .makers
+            .iter()
+            .map(|maker| maker.address.clone())
+            .collect();
+        assert_eq!(remaining, vec![addr("fresh"), addr("future")]);
+        assert!(book.suppressed_makers.contains_key(&addr("boundary")));
+        assert!(book.suppressed_makers.contains_key(&addr("never")));
+    }
+
+    #[test]
+    fn cached_discovery_cannot_immediately_restore_a_pruned_maker() {
+        let ttl = STALE_MAKER_AGE.as_secs();
+        let prune_ts = ttl * 2;
+        let address = addr("cached");
+        let outpoint = Some(OutPoint::new(Txid::from_slice(&[4; 32]).unwrap(), 0));
+        let mut book = OfferBook::default();
+
+        book.insert_candidate(
+            address.clone(),
+            outpoint,
+            Some(500),
+            Some(100),
+            prune_ts - ttl,
+        );
+        assert_eq!(book.prune_stale_makers(prune_ts), 1);
+
+        assert!(!book.upsert_discovered(
+            address.clone(),
+            outpoint,
+            Some(500),
+            Some(100),
+            prune_ts + ttl - 1,
+        ));
+        assert!(book.makers.is_empty());
+
+        // The exact cooldown boundary admits one recovery probe.
+        let retry_ts = prune_ts + ttl;
+        assert!(book.upsert_discovered(address.clone(), outpoint, Some(500), Some(100), retry_ts));
+        assert_eq!(book.makers.len(), 1);
+        assert!(!book.suppressed_makers.contains_key(&address));
+
+        // Without a successful offer, the next cycle suppresses it again.
+        book.mark_failure(&address, retry_ts);
+        assert_eq!(book.prune_stale_makers(retry_ts), 1);
+        assert!(book.makers.is_empty());
+    }
+
+    #[test]
+    fn newer_announcement_restores_a_pruned_maker_after_a_successful_probe() {
+        let ttl = STALE_MAKER_AGE.as_secs();
+        let prune_ts = ttl * 2;
+        let retry_ts = prune_ts + 1;
+        let address = addr("recovered");
+        let outpoint = Some(OutPoint::new(Txid::from_slice(&[5; 32]).unwrap(), 0));
+        let mut book = OfferBook::default();
+
+        book.insert_candidate(
+            address.clone(),
+            outpoint,
+            Some(500),
+            Some(100),
+            prune_ts - ttl,
+        );
+        assert_eq!(book.prune_stale_makers(prune_ts), 1);
+        assert!(book.upsert_discovered(address.clone(), outpoint, Some(500), Some(101), retry_ts));
+
+        book.mark_success(
+            &address,
+            dummy_offer(&address.to_string()),
+            MakerProtocol::Unified,
+            retry_ts,
+        );
+
+        assert_eq!(book.prune_stale_makers(retry_ts + ttl - 1), 0);
+        assert_eq!(book.makers[0].state, MakerState::Good);
+        assert_eq!(book.makers[0].last_offer_update_ts, Some(retry_ts));
+    }
+
+    #[test]
+    fn changed_bond_or_manual_poll_bypasses_suppression() {
+        let ttl = STALE_MAKER_AGE.as_secs();
+        let prune_ts = ttl * 2;
+        let address = addr("returning");
+        let old_outpoint = Some(OutPoint::new(Txid::from_slice(&[6; 32]).unwrap(), 0));
+        let new_outpoint = Some(OutPoint::new(Txid::from_slice(&[7; 32]).unwrap(), 0));
+        let mut book = OfferBook::default();
+
+        book.insert_candidate(
+            address.clone(),
+            old_outpoint,
+            Some(500),
+            Some(100),
+            prune_ts - ttl,
+        );
+        assert_eq!(book.prune_stale_makers(prune_ts), 1);
+        assert!(book.upsert_discovered(
+            address.clone(),
+            new_outpoint,
+            Some(600),
+            Some(100),
+            prune_ts + 1,
+        ));
+        assert_eq!(book.makers[0].first_seen_ts, Some(prune_ts + 1));
+
+        book.makers[0].first_seen_ts = Some(prune_ts - ttl);
+        assert_eq!(book.prune_stale_makers(prune_ts), 1);
+        assert!(book.upsert_for_poll(address.clone(), prune_ts + 2));
+        assert_eq!(book.makers[0].first_seen_ts, Some(prune_ts + 2));
+        assert!(!book.suppressed_makers.contains_key(&address));
+    }
+
+    #[test]
+    fn expired_bond_removes_its_suppression_record() {
+        let ttl = STALE_MAKER_AGE.as_secs();
+        let now_ts = ttl * 2;
+        let address = addr("expired");
+        let outpoint = Some(OutPoint::new(Txid::from_slice(&[8; 32]).unwrap(), 0));
+        let mut book = OfferBook::default();
+
+        book.insert_candidate(address.clone(), outpoint, Some(500), None, now_ts - ttl);
+        assert_eq!(book.prune_stale_makers(now_ts), 1);
+        assert_eq!(book.prune_expired_suppressions(499), 0);
+        assert_eq!(book.prune_expired_suppressions(500), 1);
+        assert!(!book.suppressed_makers.contains_key(&address));
+    }
+
+    #[test]
+    fn suppression_state_round_trips_and_missing_map_defaults() {
+        let ttl = STALE_MAKER_AGE.as_secs();
+        let now_ts = ttl * 2;
+        let address = addr("persisted");
+        let mut book = OfferBook::default();
+
+        book.insert_candidate(address.clone(), None, None, Some(100), now_ts - ttl);
+        assert_eq!(book.prune_stale_makers(now_ts), 1);
+
+        let encoded = serde_json::to_string(&book).unwrap();
+        let decoded: OfferBook = serde_json::from_str(&encoded).unwrap();
+        assert_eq!(decoded.suppressed_makers, book.suppressed_makers);
+
+        let mut legacy: serde_json::Value = serde_json::from_str(&encoded).unwrap();
+        legacy.as_object_mut().unwrap().remove("suppressed_makers");
+        let decoded_legacy: OfferBook = serde_json::from_value(legacy).unwrap();
+        assert!(decoded_legacy.suppressed_makers.is_empty());
+    }
+
+    #[test]
+    fn legacy_candidate_fields_deserialize_and_backfill() {
+        let now_ts = STALE_MAKER_AGE.as_secs();
+        let mut book = OfferBook::default();
+        book.insert_candidate(addr("legacy"), None, None, None, now_ts);
+
+        let mut encoded = serde_json::to_value(&book).unwrap();
+        let candidate = encoded
+            .get_mut("makers")
+            .and_then(serde_json::Value::as_array_mut)
+            .and_then(|makers| makers.first_mut())
+            .and_then(serde_json::Value::as_object_mut)
+            .unwrap();
+        candidate.remove("fidelity_expiry_height");
+        candidate.remove("first_seen_ts");
+        candidate.remove("last_announcement_ts");
+
+        let mut decoded: OfferBook = serde_json::from_value(encoded).unwrap();
+        assert_eq!(decoded.makers[0].fidelity_expiry_height, None);
+        assert_eq!(decoded.makers[0].first_seen_ts, None);
+        assert_eq!(decoded.makers[0].last_announcement_ts, None);
+
+        assert!(decoded.backfill_first_seen_timestamps(now_ts));
+        assert_eq!(decoded.makers[0].first_seen_ts, Some(now_ts));
+        assert!(!decoded.backfill_first_seen_timestamps(now_ts + 1));
     }
 
     #[test]

--- a/src/watch_tower/nostr.rs
+++ b/src/watch_tower/nostr.rs
@@ -394,7 +394,10 @@ fn handle_relay_message(
             // Claim the txid before any RPC work, so duplicate events and
             // concurrent relay sessions don't repeat the fetch and validation.
             if !lock_debug!(seen_txid.lock())?.claim(txid) {
-                log::info!("Skipping already-seen txid {txid} via {relay_url}");
+                let refreshed = registry.touch_fidelity_announcement(txid, cursor)?;
+                log::info!(
+                    "Skipping already-seen txid {txid} via {relay_url}; refreshed={refreshed}"
+                );
                 registry.save_nostr_cursor(relay_url, cursor)?;
                 return Ok(false);
             }
@@ -418,7 +421,7 @@ fn handle_relay_message(
                 Some(fidelity) => {
                     let maker_address = fidelity.onion.clone();
                     let expires_at_height = fidelity.expires_at_height;
-                    if registry.insert_fidelity(txid, fidelity)? {
+                    if registry.insert_fidelity_announcement(txid, fidelity, cursor)? {
                         log::info!(
                                 "Stored verified fidelity | relay={} | event_id={} | txid={} | vout={} | maker_address={} | expires_at_height={}",
                                 relay_url,

--- a/src/watch_tower/registry_storage.rs
+++ b/src/watch_tower/registry_storage.rs
@@ -35,6 +35,9 @@ pub struct Fidelity {
     pub onion_address: String,
     /// Fidelity expiry height used later for pruning.
     pub expire_height: u32,
+    /// Creation time of the newest verified Nostr announcement for this bond.
+    /// Chain-only discovery has no announcement timestamp.
+    pub last_announcement_ts: Option<u64>,
 }
 
 /// Nostr cursors and fidelity records are per-boot by design: the relays are the
@@ -44,6 +47,7 @@ pub struct Fidelity {
 struct RegistryData {
     watches: HashMap<OutPoint, WatchRequest>,
     fidelity: HashSet<Fidelity>,
+    fidelity_announcement_ts: HashMap<Txid, u64>,
     nostr_cursors: HashMap<String, u64>,
 }
 
@@ -118,34 +122,90 @@ impl FileRegistry {
     /// Returns all stored maker fidelity records.
     pub fn list_fidelity(&self, height: u32) -> Result<HashSet<Fidelity>, WatcherError> {
         self.with_data(|data| {
-            data.fidelity = data
-                .fidelity
+            data.fidelity
+                .retain(|fidelity| fidelity.expire_height > height);
+            let active_txids: HashSet<_> =
+                data.fidelity.iter().map(|fidelity| fidelity.txid).collect();
+            data.fidelity_announcement_ts
+                .retain(|txid, _| active_txids.contains(txid));
+
+            data.fidelity
                 .iter()
-                .filter(|v| v.expire_height > height)
                 .cloned()
-                .collect();
-            data.fidelity.clone()
+                .map(|mut fidelity| {
+                    fidelity.last_announcement_ts =
+                        data.fidelity_announcement_ts.get(&fidelity.txid).copied();
+                    fidelity
+                })
+                .collect()
         })
     }
 
-    /// Inserts a new fidelity record.
+    /// Inserts a fidelity record learned directly from the chain.
     pub fn insert_fidelity(
         &self,
         txid: Txid,
         fidelity_announcement: FidelityAnnouncement,
     ) -> Result<bool, WatcherError> {
+        self.insert_fidelity_inner(txid, fidelity_announcement, None)
+    }
+
+    /// Inserts a fidelity record from a verified Nostr event and records the
+    /// event creation time used by offerbook stale-maker recovery.
+    pub fn insert_fidelity_announcement(
+        &self,
+        txid: Txid,
+        fidelity_announcement: FidelityAnnouncement,
+        announced_at_ts: u64,
+    ) -> Result<bool, WatcherError> {
+        self.insert_fidelity_inner(txid, fidelity_announcement, Some(announced_at_ts))
+    }
+
+    fn insert_fidelity_inner(
+        &self,
+        txid: Txid,
+        fidelity_announcement: FidelityAnnouncement,
+        announced_at_ts: Option<u64>,
+    ) -> Result<bool, WatcherError> {
         let fidelity = Fidelity {
             txid,
             onion_address: fidelity_announcement.onion,
             expire_height: fidelity_announcement.expires_at_height,
+            last_announcement_ts: None,
         };
-        let is_in = self.with_data(|data| data.fidelity.insert(fidelity))?;
+        let is_in = self.with_data(|data| {
+            if let Some(timestamp) = announced_at_ts {
+                let latest = data.fidelity_announcement_ts.entry(txid).or_default();
+                *latest = (*latest).max(timestamp);
+            }
+            data.fidelity.insert(fidelity)
+        })?;
         Ok(is_in)
+    }
+
+    /// Advances the announcement time for an already-verified fidelity record.
+    /// Returns `false` when the txid is not present in the registry.
+    pub fn touch_fidelity_announcement(
+        &self,
+        txid: Txid,
+        announced_at_ts: u64,
+    ) -> Result<bool, WatcherError> {
+        self.with_data(|data| {
+            let Some(latest) = data.fidelity_announcement_ts.get_mut(&txid) else {
+                return false;
+            };
+
+            *latest = (*latest).max(announced_at_ts);
+            true
+        })
     }
 
     /// Removes fidelity records matching the given txid.
     pub fn remove_fidelity(&mut self, txid: Txid) -> Result<(), WatcherError> {
-        self.with_data(|data| data.fidelity.retain(|f| f.txid != txid))?;
+        self.with_data(|data| {
+            data.fidelity.retain(|fidelity| fidelity.txid != txid);
+            data.fidelity_announcement_ts.remove(&txid);
+        })?;
         Ok(())
     }
 
@@ -305,6 +365,44 @@ mod tests {
 
         let list2 = reg.list_fidelity(0).unwrap();
         assert_eq!(list2.len(), 0);
+    }
+
+    #[test]
+    fn fidelity_announcement_timestamp_only_moves_forward() {
+        let mut reg = FileRegistry::new();
+        let txid = dummy_txid(1);
+        let announcement = FidelityAnnouncement {
+            onion: "abc.onion".to_string(),
+            expires_at_height: 212,
+        };
+
+        assert!(reg
+            .insert_fidelity_announcement(txid, announcement, 100)
+            .unwrap());
+        assert_eq!(
+            reg.list_fidelity(0)
+                .unwrap()
+                .iter()
+                .find(|fidelity| fidelity.txid == txid)
+                .unwrap()
+                .last_announcement_ts,
+            Some(100)
+        );
+
+        assert!(reg.touch_fidelity_announcement(txid, 99).unwrap());
+        assert!(reg.touch_fidelity_announcement(txid, 101).unwrap());
+        assert_eq!(
+            reg.list_fidelity(0)
+                .unwrap()
+                .iter()
+                .find(|fidelity| fidelity.txid == txid)
+                .unwrap()
+                .last_announcement_ts,
+            Some(101)
+        );
+
+        reg.remove_fidelity(txid).unwrap();
+        assert!(!reg.touch_fidelity_announcement(txid, 102).unwrap());
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- Prune maker offers that have not synced successfully for `48 hours`, with backward-compatible(though it's not required at this point but good to have) timestamp migration.
- Track maker announcement freshness and retain compact suppression records to prevent stale cached announcements  from restoring pruned offers.
- Restore makers on a fresh announcement, changed fidelity bond, manual poll, or retry cooldown.

## Testing
Added unit tests for covering behavior

## Checklist
- [x] Tests were added or updated where needed
- [x] Formatting and lints pass
- [x] Documentation was updated where needed
- [ ] Security or protocol impact is explained above, if applicable


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Offer listings now hide makers without a successful offer for two days.
  - Suppressed makers can reappear through recovery checks, explicit refreshes, bond changes, or expiry events.
  - Offer records retain first-seen timing and fidelity expiry information.
  - Backend failures schedule non-penalizing retries.

- **Bug Fixes**
  - Invalid or tampered fidelity announcements are rejected before processing.
  - Expired fidelity records are removed automatically.

- **Data Updates**
  - Existing saved records are updated with missing timing information when loaded.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->